### PR TITLE
Update the rustdocs header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-//! # rust-bitcoin-coin-selection
-//! Helper functions to select a set of UTXOs from a given UTXO pool to reach
-//! a given target amount.
+//! Rust Bitcoin coin selection library.
 //!
+//! This library provides efficient algorithms to compose a set of unspent transaction outputs
+//! (UTXOs).
 
 #[cfg(any(test, feature = "rand"))]
 use rand::{seq::SliceRandom, thread_rng};


### PR DESCRIPTION
Update the documentation header to match other rust bitcoin projects.  For example: https://docs.rs/bitcoin_hashes/0.11.0/bitcoin_hashes/