### PR TITLE
Feature/benchmark

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -35,3 +35,8 @@ fi
 if [ "$DO_DOCS" = true ]; then
     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --all-features -- -D rustdoc::broken-intra-doc-links -D warnings || exit 1
 fi
+
+# Bench if told to, only works with non-stable toolchain (nightly, beta).
+if [ "$DO_BENCH" = true ]; then
+    RUSTFLAGS='--cfg=bench' cargo bench
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,11 @@
 #![deny(missing_docs)]
 
 // Experimental features we need.
+#![cfg_attr(bench, feature(test))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(bench)]
+extern crate test;
 
 use std::cmp::Reverse;
 
@@ -171,7 +175,9 @@ mod tests {
     }
 
     impl Utxo for MinimalUtxo {
-        fn get_value(&self) -> u64 { self.value }
+        fn get_value(&self) -> u64 {
+            self.value
+        }
     }
 
     #[test]
@@ -323,5 +329,51 @@ mod tests {
         let utxo_match = select_coins(5000000358, 20, &mut test_utxo_pool);
 
         assert!(utxo_match.is_none());
+    }
+}
+
+#[cfg(bench)]
+mod benches {
+    use crate::select_coins_bnb;
+    use crate::Utxo;
+    use test::Bencher;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct MinimalUtxo {
+        value: u64,
+    }
+
+    impl Utxo for MinimalUtxo {
+        fn get_value(&self) -> u64 {
+            self.value
+        }
+    }
+
+    #[bench]
+    /// Creates a UTXO pool of 1,000 coins that do not match and one coin
+    /// that will be a match when combined with any of the other 1,000 coins.
+    ///
+    /// Matching benchmark of Bitcoin core coin-selection benchmark.
+    // https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/src/bench/coin_selection.cpp#L44
+    fn bench_select_coins_bnb(bh: &mut Bencher) {
+        // https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/src/consensus/amount.h#L15
+        /// The amount of satoshis in one BTC.
+        const COIN: u64 = 100_000_000;
+
+        // https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/src/wallet/coinselection.h#L18
+        /// lower bound for randomly-chosen target change amount
+        const CHANGE_LOWER: u64 = 50_000;
+
+        let u = MinimalUtxo { value: 1000 * COIN };
+        let mut utxo_pool = vec![u; 1000];
+        utxo_pool.push(MinimalUtxo { value: 3 * COIN });
+
+        bh.iter(|| {
+            let result =
+                select_coins_bnb(1003 * COIN, CHANGE_LOWER, &mut utxo_pool.clone()).unwrap();
+            assert_eq!(2, result.len());
+            assert_eq!(1000 * COIN, result[0].value);
+            assert_eq!(3 * COIN, result[1].value);
+        });
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/2

The benchmark I added matches the benchmark in Bitcoin Core so an accurate comparison can be made.  The current results for this benchmark:

```
test benches::bench_select_coins_bnb ... bench:   1,234,158 ns/iter (+/- 523)`
```

I also ran the benchmark for Bitcoin Core to see how it stacks up:
```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|        1,021,008.00 |              979.42 |    4.9% |      0.01 | `CoinSelection`
```

It seems that the current rust implementation is ~200 ns slower, although I can think of some optimizations that can bring the results closer :nerd_face: .
