### PR TITLE
Examine all possible combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 
 [dependencies]
 rand = {version = "0.8.5", default-features = false, optional = true}
+combinations = "0.1.0"
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
Closes https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/20

Try all possible combinations and record the best match.  This is of course very slow and needs to be improved before is ready to use on large size UTXO pools.  The number of possible combinations of a pool size of `n`would be:

The summation (sigma) for k from i..n of `C(n, k)= n!/[k!(n-k)!] `