### PR TITLE
Return Iterator instead of Vector for SRD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,15 +59,11 @@ pub struct WeightedUtxo {
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 pub fn select_coins<T: Utxo>(
     target: Amount,
-    cost_of_change: u64,
+    _cost_of_change: u64,
     fee_rate: FeeRate,
     weighted_utxos: &mut [WeightedUtxo],
-    utxo_pool: &mut [T],
-) -> Option<Vec<WeightedUtxo>> {
-    match select_coins_bnb(target.to_sat(), cost_of_change, utxo_pool) {
-        Some(_res) => Some(Vec::new()),
-        None => select_coins_srd(target, fee_rate, weighted_utxos, &mut thread_rng()),
-    }
+) -> Option<impl Iterator<Item = &'_ WeightedUtxo>> {
+    select_coins_srd(target, fee_rate, weighted_utxos, &mut thread_rng())
 }
 
 /// Select coins using BnB algorithm similar to what is done in bitcoin


### PR DESCRIPTION
Return Iterator instead of Vector for SRD.

The caller may prefer to work with an Iterator instead of a vec.  If the caller prefers a vec, they can use `collect()`.  This is the first commit to close https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/31