### PR TITLE
Feature/coin struct

### DIFF
--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -3,23 +3,34 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use bitcoin::Amount;
 use bitcoin::FeeRate;
 use bitcoin::ScriptBuf;
+use bitcoin::SignedAmount;
 use bitcoin::TxOut;
-use bitcoin::Weight;
 use rust_bitcoin_coin_selection::select_coins_bnb;
-use rust_bitcoin_coin_selection::WeightedUtxo;
+use rust_bitcoin_coin_selection::Coin;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/src/wallet/coinselection.h#L18
     let cost_of_change = Amount::from_sat(50_000);
 
-    let one = WeightedUtxo {
-        satisfaction_weight: Weight::ZERO,
-        utxo: TxOut { value: Amount::from_sat(1_000), script_pubkey: ScriptBuf::new() },
+    let no_op = TxOut { value: Amount::ZERO, script_pubkey: ScriptBuf::new() };
+    let fee_rate = FeeRate::ZERO;
+    let long_term_fee_rate = FeeRate::ZERO;
+    let waste = SignedAmount::ZERO;
+
+    let one = Coin {
+        utxo: no_op.clone(),
+        effective_value: Amount::from_sat(1_000),
+        waste,
+        fee_rate,
+        long_term_fee_rate,
     };
 
-    let two = WeightedUtxo {
-        satisfaction_weight: Weight::ZERO,
-        utxo: TxOut { value: Amount::from_sat(3), script_pubkey: ScriptBuf::new() },
+    let two = Coin {
+        utxo: no_op.clone(),
+        effective_value: Amount::from_sat(3),
+        waste,
+        fee_rate,
+        long_term_fee_rate,
     };
 
     let target = Amount::from_sat(1_003);
@@ -31,16 +42,14 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let result: Vec<_> = select_coins_bnb(
                 black_box(target),
                 black_box(cost_of_change),
-                black_box(FeeRate::ZERO),
-                black_box(FeeRate::ZERO),
                 black_box(&utxo_pool),
             )
             .unwrap()
             .collect();
 
             assert_eq!(2, result.len());
-            assert_eq!(Amount::from_sat(1_000), result[0].utxo.value);
-            assert_eq!(Amount::from_sat(3), result[1].utxo.value);
+            assert_eq!(Amount::from_sat(1_000), result[0].effective_value);
+            assert_eq!(Amount::from_sat(3), result[1].effective_value);
         })
     });
 }

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -297,7 +297,8 @@ fn index_to_utxo_list(
     // refs &WeightedUtxo in `wu` have the same lifetime as the
     // returned &WeightedUtxo.
     let origin: Vec<_> = wu.iter().map(|(_, _, u)| *u).collect();
-    let mut result = origin.clone();
+
+    let mut result = vec![];
     result.clear();
 
     // copy over the origin items into result that are present

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -308,6 +308,18 @@ mod tests {
     use bitcoin::Weight;
     use core::str::FromStr;
 
+    fn select_coins_bnb_given_target(target_str: &str, expected_inputs: &[&str]) {
+        let target = Amount::from_str(target_str).unwrap();
+        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
+        let mut inputs: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
+        assert_eq!(inputs.len(), expected_inputs.len());
+
+        inputs.sort();
+        for (i, _) in inputs.iter().enumerate() {
+            assert_eq!(inputs[i].utxo.value, Amount::from_str(expected_inputs[i]).unwrap());
+        }
+    }
+
     fn create_coin_from_eff_values(eff_values: Vec<Amount>) -> Vec<Coin> {
         let no_op = TxOut { value: Amount::ZERO, script_pubkey: ScriptBuf::new() };
         let fee_rate = FeeRate::ZERO;
@@ -388,126 +400,52 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_one() {
-        let target = Amount::from_str("1 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 1);
-        assert_eq!(list[0].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("1 cBTC", &["1 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_two() {
-        let target = Amount::from_str("2 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 1);
-        assert_eq!(list[0].utxo.value, Amount::from_str("2 cBTC").unwrap());
+        select_coins_bnb_given_target("2 cBTC", &["2 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_three() {
-        let target = Amount::from_str("3 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 2);
-        assert_eq!(list[0].utxo.value, Amount::from_str("2 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("3 cBTC", &["1 cBTC", "2 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_four() {
-        let target = Amount::from_str("4 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 2);
-        assert_eq!(list[0].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("4 cBTC", &["1 cBTC", "3 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_five() {
-        let target = Amount::from_str("5 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 2);
-        assert_eq!(list[0].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("2 cBTC").unwrap());
+        select_coins_bnb_given_target("5 cBTC", &["2 cBTC", "3 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_six() {
-        let target = Amount::from_str("6 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 3);
-        assert_eq!(list[0].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("2 cBTC").unwrap());
-        assert_eq!(list[2].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("6 cBTC", &["1 cBTC", "2 cBTC", "3 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_seven() {
-        let target = Amount::from_str("7 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 3);
-        assert_eq!(list[0].utxo.value, Amount::from_str("4 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("2 cBTC").unwrap());
-        assert_eq!(list[2].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("7 cBTC", &["1 cBTC", "2 cBTC", "4 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_eight() {
-        let target = Amount::from_str("8 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 3);
-        assert_eq!(list[0].utxo.value, Amount::from_str("4 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[2].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("8 cBTC", &["1 cBTC", "3 cBTC", "4 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_nine() {
-        let target = Amount::from_str("9 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 3);
-        assert_eq!(list[0].utxo.value, Amount::from_str("4 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[2].utxo.value, Amount::from_str("2 cBTC").unwrap());
+        select_coins_bnb_given_target("9 cBTC", &["2 cBTC", "3 cBTC", "4 cBTC"]);
     }
 
     #[test]
     fn select_coins_bnb_ten() {
-        let target = Amount::from_str("10 cBTC").unwrap();
-        let coin = create_coin(FeeRate::ZERO, FeeRate::ZERO);
-
-        let list: Vec<_> = select_coins_bnb(target, Amount::ZERO, &coin).unwrap().collect();
-
-        assert_eq!(list.len(), 4);
-        assert_eq!(list[0].utxo.value, Amount::from_str("4 cBTC").unwrap());
-        assert_eq!(list[1].utxo.value, Amount::from_str("3 cBTC").unwrap());
-        assert_eq!(list[2].utxo.value, Amount::from_str("2 cBTC").unwrap());
-        assert_eq!(list[3].utxo.value, Amount::from_str("1 cBTC").unwrap());
+        select_coins_bnb_given_target("10 cBTC", &["1 cBTC", "2 cBTC", "3 cBTC", "4 cBTC"]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,34 +40,60 @@ pub trait Utxo: Clone {
 // https://github.com/bitcoin/bitcoin/blob/f722a9bd132222d9d5cd503b5af25c905b205cdb/src/wallet/coinselection.h#L20
 const CHANGE_LOWER: Amount = Amount::from_sat(50_000);
 
-/// This struct contains the weight of all params needed to satisfy the UTXO.
-///
-/// The idea of using a WeightUtxo type was inspired by the BDK implementation:
-/// <https://github.com/bitcoindevkit/bdk/blob/feafaaca31a0a40afc03ce98591d151c48c74fa2/crates/bdk/src/types.rs#L181>
-#[derive(Clone, Debug, PartialEq)]
-// note, change this to private?  No good reason to be public.
-pub struct WeightedUtxo {
-    /// The satisfaction_weight is the size of the required params to satisfy the UTXO.
-    pub satisfaction_weight: Weight,
-    /// The corresponding UTXO.
-    pub utxo: TxOut,
+fn calculate_effective_value(
+    fee_rate: FeeRate,
+    value: Amount,
+    satisfaction_weight: Weight,
+) -> Option<SignedAmount> {
+    let signed_input_fee = calculate_fee(fee_rate, satisfaction_weight)?.to_signed().ok()?;
+    value.to_signed().ok()?.checked_sub(signed_input_fee)
 }
 
-impl WeightedUtxo {
-    fn effective_value(&self, fee_rate: FeeRate) -> Option<SignedAmount> {
-        let signed_input_fee = self.calculate_fee(fee_rate)?.to_signed().ok()?;
-        self.utxo.value.to_signed().ok()?.checked_sub(signed_input_fee)
-    }
+fn calculate_fee(fee_rate: FeeRate, satisfaction_weight: Weight) -> Option<Amount> {
+    let weight = satisfaction_weight.checked_add(TxIn::BASE_WEIGHT)?;
+    fee_rate.checked_mul_by_weight(weight)
+}
 
-    fn calculate_fee(&self, fee_rate: FeeRate) -> Option<Amount> {
-        let weight = self.satisfaction_weight.checked_add(TxIn::BASE_WEIGHT)?;
-        fee_rate.checked_mul_by_weight(weight)
-    }
+fn calculate_waste(
+    fee_rate: FeeRate,
+    long_term_fee_rate: FeeRate,
+    satisfaction_weight: Weight,
+) -> Option<SignedAmount> {
+    let fee: SignedAmount = calculate_fee(fee_rate, satisfaction_weight)?.to_signed().ok()?;
+    let lt_fee: SignedAmount =
+        calculate_fee(long_term_fee_rate, satisfaction_weight)?.to_signed().ok()?;
+    fee.checked_sub(lt_fee)
+}
 
-    fn waste(&self, fee_rate: FeeRate, long_term_fee_rate: FeeRate) -> Option<SignedAmount> {
-        let fee: SignedAmount = self.calculate_fee(fee_rate)?.to_signed().ok()?;
-        let lt_fee: SignedAmount = self.calculate_fee(long_term_fee_rate)?.to_signed().ok()?;
-        fee.checked_sub(lt_fee)
+/// TODO
+#[derive(Clone, Debug)]
+pub struct Coin {
+    /// TODO
+    pub utxo: TxOut,
+    /// TODO
+    pub effective_value: Amount,
+    /// TODO
+    pub waste: SignedAmount,
+    /// TODO
+    pub fee_rate: FeeRate,
+    /// TODO
+    pub long_term_fee_rate: FeeRate,
+}
+
+/// TODO
+impl Coin {
+    /// TODO
+    pub fn new(
+        utxo: TxOut,
+        fee_rate: FeeRate,
+        long_term_fee_rate: FeeRate,
+        satisfaction_weight: Weight,
+    ) -> Option<Self> {
+        let effective_value = calculate_effective_value(fee_rate, utxo.value, satisfaction_weight)?
+            .to_unsigned()
+            .ok()?;
+        let waste = calculate_waste(fee_rate, long_term_fee_rate, satisfaction_weight)?;
+        Some(Self { utxo, effective_value, waste, fee_rate, long_term_fee_rate })
     }
 }
 
@@ -81,18 +107,73 @@ impl WeightedUtxo {
 pub fn select_coins<T: Utxo>(
     target: Amount,
     cost_of_change: Amount,
-    fee_rate: FeeRate,
-    long_term_fee_rate: FeeRate,
-    weighted_utxos: &[WeightedUtxo],
-) -> Option<impl Iterator<Item = &WeightedUtxo>> {
+    coins: &[Coin],
+) -> Option<impl Iterator<Item = &Coin>> {
     {
-        let bnb =
-            select_coins_bnb(target, cost_of_change, fee_rate, long_term_fee_rate, weighted_utxos);
+        let bnb = select_coins_bnb(target, cost_of_change, coins);
 
         if bnb.is_some() {
             bnb
         } else {
-            select_coins_srd(target, fee_rate, weighted_utxos, &mut thread_rng())
+            select_coins_srd(target, coins, &mut thread_rng())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::ScriptBuf;
+    use core::str::FromStr;
+
+    #[test]
+    fn coin_constructor_negative_effective_value() {
+        let tx_out =
+            TxOut { value: Amount::from_str("1 sat").unwrap(), script_pubkey: ScriptBuf::new() };
+
+        let fee_rate: FeeRate = FeeRate::from_sat_per_kwu(10);
+        let coin = Coin::new(tx_out, fee_rate, FeeRate::ZERO, Weight::ZERO);
+        assert!(coin.is_none());
+    }
+
+    #[test]
+    fn coin_constructor_typical() {
+        let tx_out =
+            TxOut { value: Amount::from_str("46 sats").unwrap(), script_pubkey: ScriptBuf::new() };
+
+        let fee_rate: FeeRate = FeeRate::from_sat_per_kwu(10);
+        let lt_fee_rate: FeeRate = FeeRate::from_sat_per_kwu(15);
+        let satisfaction_weight = Weight::from_wu(204);
+
+        let coin = Coin::new(tx_out.clone(), fee_rate, lt_fee_rate, satisfaction_weight).unwrap();
+
+        // effective_vale = value - fee
+        // fee = satisfaction_weight + base_weight * fee_rate
+        //
+        // effective_value = 46 sats - (204 wu + 160 wu) * 10 sat/kwu = 42 sats
+        assert_eq!(coin.effective_value, Amount::from_str("42 sats").unwrap());
+
+        // waste = fee - long term fee
+        // waste = (fee_rate * weight) - (lt_fee_fee_rate * weight)
+        //       = (10 sat/kwu * (204 wu + 160 wu)) - (15 sat/kwu * (204 wu + 160 wu))
+        // waste = -2 sats
+        assert_eq!(coin.waste, SignedAmount::from_str("-2 sats").unwrap());
+
+        assert_eq!(coin.utxo, tx_out);
+    }
+
+    #[test]
+    fn coin_constructor_overflow() {
+        let tx_out =
+            TxOut { value: Amount::from_str("1 cBTC").unwrap(), script_pubkey: ScriptBuf::new() };
+
+        let coin = Coin::new(tx_out.clone(), FeeRate::MAX, FeeRate::ZERO, Weight::ZERO);
+        assert!(coin.is_none());
+
+        let coin = Coin::new(tx_out.clone(), FeeRate::ZERO, FeeRate::ZERO, Weight::MAX);
+        assert!(coin.is_none());
+
+        let coin = Coin::new(tx_out, FeeRate::ZERO, FeeRate::MAX, Weight::ZERO);
+        assert!(coin.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ fn calculate_waste(
 }
 
 /// TODO
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Ord, Eq, PartialEq, PartialOrd)]
 pub struct Coin {
     /// TODO
     pub utxo: TxOut,

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -34,15 +34,13 @@ pub fn select_coins_srd<'a, R: rand::Rng + ?Sized>(
     weighted_utxos: &'a [WeightedUtxo],
     rng: &mut R,
 ) -> Option<std::vec::IntoIter<&'a WeightedUtxo>> {
-    let mut result: Vec<_> = weighted_utxos.iter().collect();
-    let mut origin = result.to_owned();
+    let mut origin: Vec<_> = weighted_utxos.iter().collect();
     origin.shuffle(rng);
-
-    result.clear();
 
     let threshold = target + CHANGE_LOWER;
     let mut value = Amount::ZERO;
 
+    let mut result = vec![];
     for w_utxo in origin {
         let utxo_value = w_utxo.utxo.value;
         let effective_value = effective_value(fee_rate, w_utxo.satisfaction_weight, utxo_value)?;


### PR DESCRIPTION
- Create a struct `Coin` that pre-processes the required attributes for coin-selection (effective_value and waste).  Previously both BNB and SRD would calculate effective_value separately and test effective_value separately. https://github.com/p2pderivatives/rust-bitcoin-coin-selection/pull/45/commits/d71f6a9468f002a5464ffdf257f13917165c539e closes [43](https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/43)
- Refactor test-suit https://github.com/p2pderivatives/rust-bitcoin-coin-selection/pull/45/commits/88760cb4bed42916e3fa843c001558953341e1f1 closes [41](https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/41)