### PR TITLE
Add BnB proptest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-  "bitcoin-coin-selection", "fuzz",
+  "bitcoin-coin-selection", "fuzz", "prop",
 ]
 resolver = "1"

--- a/prop/Cargo.toml
+++ b/prop/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prop"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+proptest = "1.5.0"
+bitcoin-coin-selection = { path = "../bitcoin-coin-selection", features = ["rand"] }
+bitcoin = { git = "https://github.com/yancyribbens/rust-bitcoin.git", rev = "edcd2fb5d78be71a60709d18fb367fd56171ff26" }
+rand = "0.8.5"

--- a/prop/src/main.rs
+++ b/prop/src/main.rs
@@ -1,0 +1,84 @@
+use bitcoin::Amount;
+use bitcoin::FeeRate;
+use bitcoin::ScriptBuf;
+use bitcoin::TxOut;
+use bitcoin::Weight;
+use proptest::prelude::*;
+
+use bitcoin_coin_selection::select_coins_bnb;
+use bitcoin_coin_selection::WeightedUtxo;
+
+#[derive(Clone, Debug)]
+pub struct Utxo {
+    output: TxOut,
+    satisfaction_weight: Weight,
+}
+
+impl WeightedUtxo for Utxo {
+    fn satisfaction_weight(&self) -> Weight {
+        self.satisfaction_weight
+    }
+
+    fn value(&self) -> Amount {
+        self.output.value
+    }
+}
+
+fn build_pool(vec: &mut Vec<(u8, bool)>) -> Vec<Utxo> {
+    vec.into_iter()
+        .map(|(u, _b)| u64::from(*u))
+        .map(|a| {
+            let output = TxOut {
+                value: Amount::from_sat(a),
+                script_pubkey: ScriptBuf::new()
+            };
+
+            let satisfaction_weight = Weight::ZERO;
+
+            Utxo {
+                output,
+                satisfaction_weight
+            }
+        })
+    .collect()
+}
+
+fn create_target_amt_from(pool: &Vec<(u8, bool)>) -> Amount {
+    pool.iter().fold(Amount::ZERO, |acc, (u, b)|
+        {
+            if *b {
+                acc + Amount::from_sat(u64::from(*u))
+            } else {
+                acc
+            }
+        }
+    )
+}
+
+proptest! {
+    #[test]
+    // Vec<u8> is used here so that when the sum is done
+    // later, that it does not overflow.
+    fn test_bnb_arbitrary_pool(ref mut vec in any::<Vec<(u8, bool)>>()) {
+        vec.truncate(10);
+        let pool: Vec<_> = build_pool(vec);
+        let target = create_target_amt_from(&vec);
+
+        let selection: Vec<Amount> =
+            select_coins_bnb(
+                target,
+                Amount::ZERO,
+                FeeRate::ZERO,
+                FeeRate::ZERO,
+                &pool)
+            .unwrap()
+            .map(|i| i.value()).collect();
+
+        let sum: Amount = selection.into_iter().sum();
+        assert_eq!(target, sum);
+    }
+}
+
+fn main() {
+    test_bnb_arbitrary_pool();
+}

--- a/prop/src/main.rs
+++ b/prop/src/main.rs
@@ -8,6 +8,8 @@ use proptest::prelude::*;
 use bitcoin_coin_selection::select_coins_bnb;
 use bitcoin_coin_selection::WeightedUtxo;
 
+use std::str::FromStr;
+
 #[derive(Clone, Debug)]
 pub struct Utxo {
     output: TxOut,
@@ -43,6 +45,26 @@ fn build_pool(vec: &mut Vec<(u8, bool)>) -> Vec<Utxo> {
     .collect()
 }
 
+fn build_linear_pool() -> Vec<Utxo> {
+    (1..10)
+        .map(|i| format!("{} cBTC", i))
+        .map(|s| Amount::from_str(&s).unwrap())
+        .map(|a| {
+            let output = TxOut {
+                value: a,
+                script_pubkey: ScriptBuf::new()
+            };
+
+            let satisfaction_weight = Weight::ZERO;
+
+            Utxo {
+                output,
+                satisfaction_weight
+            }
+        })
+    .collect()
+}
+
 fn create_target_amt_from(pool: &Vec<(u8, bool)>) -> Amount {
     pool.iter().fold(Amount::ZERO, |acc, (u, b)|
         {
@@ -61,6 +83,7 @@ proptest! {
     // later, that it does not overflow.
     fn test_bnb_arbitrary_pool(ref mut vec in any::<Vec<(u8, bool)>>()) {
         vec.truncate(10);
+
         let pool: Vec<_> = build_pool(vec);
         let target = create_target_amt_from(&vec);
 
@@ -77,8 +100,28 @@ proptest! {
         let sum: Amount = selection.into_iter().sum();
         assert_eq!(target, sum);
     }
+
+    #[test]
+    fn test_bnb_arbitrary_target(t in any::<u64>()) {
+        let target_str = format!("{} cBTC", t % 10);
+        let target = Amount::from_str(&target_str).unwrap();
+        let pool = build_linear_pool();
+
+        let selection_sum: Amount =
+            select_coins_bnb(
+                target,
+                Amount::ZERO,
+                FeeRate::ZERO,
+                FeeRate::ZERO,
+                &pool)
+            .unwrap()
+            .map(|i| i.value()).sum();
+
+        assert_eq!(selection_sum, target);
+    }
 }
 
 fn main() {
     test_bnb_arbitrary_pool();
+    test_bnb_arbitrary_target();
 }


### PR DESCRIPTION
Add a prop test for BnB

1) Create a random pool of coins that is at most 10 coins.  Limit to 10 so that the iteration limit of 100,000 isn't exceeded.
2) Add up all the even valued coins and use that as the target (hypothetical spend amount).
3) Assert that BnB finds a sum of coins from the pool which is the sum of the evens

run `cargo test` in `./prop` directory.