### PR TITLE
Apply previous UTXO shortcut optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A basic performance comparison between this Rust BnB implementation and [Bitcoin
 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
-|      Rust BnB|    1,000|897,810|
+|      Rust BnB|    1,000|598,370|
 |  C++ Core BnB|    1,000|816,374|
 
 Note: The measurements where recorded using rustc 1.75.  Expect worse performance with MSRV.

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -356,10 +356,16 @@ mod tests {
         UtxoPool::from_str_list(&utxo_str_list)
     }
 
-    fn assert_coin_select(target_str: &str, expected_iterations: u32, expected_inputs_str: &[&str]) {
+    fn assert_coin_select(
+        target_str: &str,
+        expected_iterations: u32,
+        expected_inputs_str: &[&str],
+    ) {
         let target = Amount::from_str(target_str).unwrap();
         let pool = build_pool();
-        let (iterations, inputs_iter) = select_coins_bnb(target, Amount::ZERO, FeeRate::ZERO, FeeRate::ZERO, &pool.utxos).unwrap();
+        let (iterations, inputs_iter) =
+            select_coins_bnb(target, Amount::ZERO, FeeRate::ZERO, FeeRate::ZERO, &pool.utxos)
+                .unwrap();
 
         assert_eq!(iterations, expected_iterations);
 
@@ -368,7 +374,11 @@ mod tests {
         assert_eq!(expected_inputs.utxos, inputs);
     }
 
-    fn assert_coin_select_params(p: &ParamsStr, expected_iterations:u32, expected_inputs_str: Option<&[&str]>) {
+    fn assert_coin_select_params(
+        p: &ParamsStr,
+        expected_iterations: u32,
+        expected_inputs_str: Option<&[&str]>,
+    ) {
         // Remove this check once iteration count is returned by error
         if expected_inputs_str.is_none() {
             assert_eq!(0, expected_iterations);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+
     use arbitrary::{Arbitrary, Result, Unstructured};
     use arbtest::arbtest;
     use bitcoin::amount::CheckedSum;

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -123,7 +123,11 @@ mod tests {
         StepRng::new(0, 0)
     }
 
-    fn assert_coin_select_params(p: &ParamsStr, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
+    fn assert_coin_select_params(
+        p: &ParamsStr,
+        expected_iterations: u32,
+        expected_inputs_str: Option<&[&str]>,
+    ) {
         // Remove this check once iteration count is returned by error
         if expected_inputs_str.is_none() {
             assert_eq!(0, expected_iterations);
@@ -145,11 +149,16 @@ mod tests {
         }
     }
 
-    fn assert_coin_select(target_str: &str, expected_iterations: u32, expected_inputs_str: &[&str]) {
+    fn assert_coin_select(
+        target_str: &str,
+        expected_iterations: u32,
+        expected_inputs_str: &[&str],
+    ) {
         let target = Amount::from_str(target_str).unwrap();
         let pool = build_pool();
 
-        let (iterations, inputs_iter) = select_coins_srd(target, FEE_RATE, &pool.utxos, &mut get_rng()).unwrap();
+        let (iterations, inputs_iter) =
+            select_coins_srd(target, FEE_RATE, &pool.utxos, &mut get_rng()).unwrap();
         assert_eq!(iterations, expected_iterations);
 
         let inputs: Vec<_> = inputs_iter.cloned().collect();


### PR DESCRIPTION
If the index_selection is not empty, and if the previous UTXO was excluded, then check the effective_value of the current UTXO.  If it has the same effective_value then skip searching this branch.