### PR TITLE
Add coin-grinder

### DIFF
--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -5,12 +5,11 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[derive(Debug, Clone)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight,
+    weight: Weight,
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight { self.satisfaction_weight }
-
+    fn weight(&self) -> Weight { self.weight }
     fn value(&self) -> Amount { self.output.value }
 }
 
@@ -20,12 +19,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let one = Utxo {
         output: TxOut { value: Amount::from_sat(1_000), script_pubkey: ScriptBuf::new() },
-        satisfaction_weight: Weight::ZERO,
+        weight: Weight::ZERO,
     };
 
     let two = Utxo {
         output: TxOut { value: Amount::from_sat(3), script_pubkey: ScriptBuf::new() },
-        satisfaction_weight: Weight::ZERO,
+        weight: Weight::ZERO,
     };
 
     let target = Amount::from_sat(1_003);

--- a/fuzz/fuzz_targets/select_coins.rs
+++ b/fuzz/fuzz_targets/select_coins.rs
@@ -8,12 +8,12 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight,
+    weight: Weight,
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/fuzz/fuzz_targets/select_coins_bnb.rs
+++ b/fuzz/fuzz_targets/select_coins_bnb.rs
@@ -8,12 +8,12 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight
+    weight: Weight
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/fuzz/fuzz_targets/select_coins_srd.rs
+++ b/fuzz/fuzz_targets/select_coins_srd.rs
@@ -9,12 +9,12 @@ use rand::thread_rng;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight
+    weight: Weight
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -321,12 +321,11 @@ mod tests {
 
     use arbitrary::{Arbitrary, Unstructured};
     use arbtest::arbtest;
-    use bitcoin::transaction::effective_value;
     use bitcoin::{Amount, Weight};
 
     use super::*;
     use crate::tests::{assert_proptest_bnb, build_utxo, Utxo, UtxoPool};
-    use crate::WeightedUtxo;
+    use crate::{effective_value, WeightedUtxo};
 
     const TX_IN_BASE_WEIGHT: u64 = 160;
 

--- a/src/coin_grinder.rs
+++ b/src/coin_grinder.rs
@@ -6,6 +6,7 @@
 //!
 use bitcoin::amount::CheckedSum;
 use bitcoin::{Amount, FeeRate, Weight};
+
 use crate::WeightedUtxo;
 
 const ITERATION_LIMIT: u32 = 100_000;
@@ -233,7 +234,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
         let (eff_value, u) = w_utxos[next_utxo_index];
 
         amount_total += eff_value;
-        weight_total += u.weight();
+        weight_total = weight_total.checked_add(u.weight())?;
 
         selection.push(next_utxo_index);
         next_utxo_index += 1;
@@ -310,7 +311,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
             // deselect
             let (eff_value, u) = w_utxos[*selection.last().unwrap()];
             amount_total -= eff_value;
-            weight_total -= u.weight();
+            weight_total = weight_total.checked_sub(u.weight())?;
             selection.pop();
 
             shift = false;
@@ -612,5 +613,23 @@ mod tests {
         let expected = vec!["1 BTC", "1 BTC"];
 
         assert_coin_select_params(&params, 7, Some(&expected));
+    }
+
+    #[test]
+    fn coins_with_max_weight() {
+        let params = ParamsStr {
+            target: "11 sats",
+            change_target: "0",
+            max_weight: "100",
+            fee_rate: "0",
+            weighted_utxos: vec![
+                "10 sats/18446744073709551615", //u64::MAX
+                "7 sats/4",
+                "5 sats/4",
+                "4 sats/18446744073709551615", //u64::MAX
+            ],
+        };
+
+        assert_coin_select_params(&params, 8, None);
     }
 }

--- a/src/coin_grinder.rs
+++ b/src/coin_grinder.rs
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+//! Coin Grinder.
+//!
+//! This module introduces the Coin Grinder selection algorithm.
+//!
+use bitcoin::amount::CheckedSum;
+use bitcoin::{Amount, FeeRate, Weight};
+use crate::WeightedUtxo;
+
+const ITERATION_LIMIT: u32 = 100_000;
+
+// The sum of UTXO amounts after this UTXO index, e.g. lookahead[5] = Σ(UTXO[6+].amount)
+fn build_lookahead<Utxo: WeightedUtxo>(
+    lookahead: Vec<(Amount, &Utxo)>,
+    available_value: Amount,
+) -> Vec<Amount> {
+    lookahead
+        .iter()
+        .map(|(e, _w)| e)
+        .scan(available_value, |state, &u| {
+            *state -= u;
+            Some(*state)
+        })
+        .collect()
+}
+
+// Creates a tuple of (effective_value, weighted_utxo)
+fn calc_effective_values<Utxo: WeightedUtxo>(
+    weighted_utxos: &[Utxo],
+    fee_rate: FeeRate,
+) -> Vec<(Amount, &Utxo)> {
+    weighted_utxos
+        .iter()
+        // calculate effective_value for each w_utxo.
+        .map(|wu| (wu.effective_value(fee_rate), wu))
+        // remove utxos that had an error in the effective_value calculation.
+        .filter(|(eff_val, _)| eff_val.is_some())
+        // unwrap the option type since we know they are not None (see previous step).
+        .map(|(eff_val, wu)| (eff_val.unwrap(), wu))
+        // filter out all effective_values that are negative.
+        .filter(|(eff_val, _)| eff_val.is_positive())
+        // all utxo effective_values are now positive (see previous step) - cast to unsigned.
+        .map(|(eff_val, wu)| (eff_val.to_unsigned().unwrap(), wu))
+        .collect()
+}
+
+// Provides a lookup to determine the minimum UTXO weight after a given index.
+fn build_min_tail_weight<Utxo: WeightedUtxo>(weighted_utxos: Vec<(Amount, &Utxo)>) -> Vec<Weight> {
+    let weights: Vec<_> = weighted_utxos.into_iter().map(|(_, u)| u.weight()).rev().collect();
+    let mut prev = Weight::MAX;
+    let mut result = Vec::new();
+    for w in weights {
+        result.push(prev);
+        prev = std::cmp::min(prev, w);
+    }
+    result.into_iter().rev().collect()
+}
+
+fn index_to_utxo_list<Utxo: WeightedUtxo>(
+    iteration: u32,
+    index_list: Vec<usize>,
+    wu: Vec<(Amount, &Utxo)>,
+) -> Option<(u32, std::vec::IntoIter<&Utxo>)> {
+    let mut result: Vec<_> = Vec::new();
+    let list = index_list;
+
+    for i in list {
+        let wu = wu[i].1;
+        result.push(wu);
+    }
+
+    if result.is_empty() {
+        None
+    } else {
+        Some((iteration, result.into_iter()))
+    }
+}
+
+/// Performs a Branch Bound search that prioritizes input weight.  That is, select the set of
+/// outputs that meets the `total_target` and has the lowest total weight.  This algorithm produces a
+/// change output unlike [`select_coins_bnb`]. Therefore, in order to ensure that
+/// the change output can be paid for, the `total_target` is calculated as target plus
+/// `change_target` where `change_target` is the budgeted amount that pays for the change output.
+/// The `change_target` is the budgeted amount to pay for the change output.
+///
+/// See also: <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/src/wallet/coinselection.cpp#L204>
+///
+/// There is discussion here: <https://murch.one/erhardt2016coinselection.pdf> at section 6.4.3
+/// that prioritizing input weight will lead to a fragmentation of the UTXO set.  Therefore, prefer
+/// this search only in extreme conditions where fee_rate is high, since a set of UTXOs with minimal
+/// weight will lead to a cheaper constructed transaction in the short term.  However, in the
+/// long-term, this prioritization can lead to more UTXOs to choose from.
+///
+/// # Parameters
+///
+/// * target: Target spend `Amount`
+/// * change_target: The minimum `Amount` that is budgeted for creating a change output
+/// * max_selection_weight: The upper bound on the acceptable weight
+/// * fee_rate: The fee_rate used to calculate the effective_value of each candidate Utxo
+/// * weighted_utxos: The candidate Weighted UTXOs from which to choose a selection from
+///
+/// # Returns
+///
+/// * `Some(Vec<WeightedUtxo>)` where `Vec<WeightedUtxo>` is some (non-empty) vector.
+///    The search result succeeded and a match was found.
+/// * `None` un-expected results OR no match found.  A future implementation can add Error types
+///   which will differentiate between an unexpected error and no match found.  Currently, a None
+///   type occurs when one or more of the following criteria are met:
+///     - Iteration limit hit
+///     - Overflow when summing the UTXO pool
+///     - Not enough potential amount to meet the target
+///     - Target Amount is zero (no match possible)
+///     - UTXO pool was searched successfully however no match was found
+pub fn select_coins<Utxo: WeightedUtxo>(
+    target: Amount,
+    change_target: Amount,
+    max_selection_weight: Weight,
+    fee_rate: FeeRate,
+    weighted_utxos: &[Utxo],
+) -> Option<(u32, std::vec::IntoIter<&Utxo>)> {
+    let mut w_utxos = calc_effective_values::<Utxo>(weighted_utxos, fee_rate);
+
+    let available_value = w_utxos.clone().into_iter().map(|(ev, _)| ev).checked_sum()?;
+
+    // descending sort by effective_value using satisfaction weight as tie breaker.
+    w_utxos.sort_by(|a, b| b.0.cmp(&a.0).then(b.1.weight().cmp(&a.1.weight())));
+
+    let lookahead = build_lookahead(w_utxos.clone(), available_value);
+    let min_tail_weight = build_min_tail_weight(w_utxos.clone());
+
+    let total_target = target + change_target;
+
+    if available_value < total_target {
+        return None;
+    }
+
+    let mut selection: Vec<usize> = vec![];
+    let mut best_selection: Vec<usize> = vec![];
+
+    let mut amount_total: Amount = Amount::ZERO;
+    let mut best_amount: Amount = Amount::MAX;
+
+    let mut weight_total: Weight = Weight::ZERO;
+    let mut best_weight: Weight = max_selection_weight;
+
+    let mut next_utxo_index = 0;
+    let mut iteration: u32 = 0;
+
+    loop {
+        // Given a target of 11, and candidate set: [10/2, 7/1, 5/1, 4/2]
+        //
+        //      o
+        //     /
+        //  10/2
+        //   /
+        // 17/3
+        //
+        // A solution 17/3 is recorded, however the total of 11 is exceeded.
+        // Therefor, 7/1 is shifted to the exclusion branch and 5/1 is added.
+        //
+        //      o
+        //     / \
+        //  10/2
+        //   / \
+        //   17/3
+        //    /
+        //  15/3
+        //
+        // This operation happens when "shift" is true.  That is, move from
+        // the inclusion branch 17/3 via the omission branch 10/2 to it's
+        // inclusion-branch child 15/3
+        let mut shift = false;
+
+        // Given a target of 11, and candidate set: [10/2, 7/1, 5/1, 4/2]
+        // Solutions, 17/3 (shift) 15/3 (shift) and 14/4 are evaluated.
+        //
+        // At this point, the leaf node 14/4 makes a shift impossible
+        // since there is not an inclusion-branch child.  In other words,
+        // this is a leaf node.
+        //
+        //      o
+        //     /
+        //  10/2
+        //    \
+        //     \
+        //     /
+        //   14/4
+        //
+        // Instead we go to the omission branch of the nodes last ancestor.
+        // That is, we "cut" removing every child of 10/2 and shift 10/2
+        // to the omission branch.
+        //
+        //      o
+        //     / \
+        //      10/2
+        let mut cut = false;
+
+        let (eff_value, u) = w_utxos[next_utxo_index];
+
+        amount_total += eff_value;
+        weight_total += u.weight();
+
+        selection.push(next_utxo_index);
+        next_utxo_index += 1;
+        iteration += 1;
+
+        let tail: usize = *selection.last().unwrap();
+        if amount_total + lookahead[tail] < total_target {
+            cut = true;
+        } else if weight_total > best_weight {
+            if w_utxos[tail].1.weight() <= min_tail_weight[tail] {
+                cut = true;
+            } else {
+                shift = true;
+            }
+        } else if amount_total >= total_target {
+            shift = true;
+            if weight_total < best_weight
+                || weight_total == best_weight && amount_total < best_amount
+            {
+                best_selection = selection.clone();
+                best_weight = weight_total;
+                best_amount = amount_total;
+            }
+        }
+
+        if iteration >= ITERATION_LIMIT {
+            return index_to_utxo_list(iteration, best_selection, w_utxos);
+        }
+
+        // check if evaluating a leaf node.
+        if next_utxo_index == w_utxos.len() {
+            cut = true;
+        }
+
+        if cut {
+            // deselect
+            let (eff_value, u) = w_utxos[*selection.last().unwrap()];
+            amount_total -= eff_value;
+            weight_total -= u.weight();
+            selection.pop();
+            shift = true;
+        }
+
+        if shift {
+            if selection.is_empty() {
+                return index_to_utxo_list(iteration, best_selection, w_utxos);
+            }
+
+            next_utxo_index = selection.last().unwrap() + 1;
+
+            // deselect
+            let (eff_value, u) = w_utxos[*selection.last().unwrap()];
+            amount_total -= eff_value;
+            weight_total -= u.weight();
+            selection.pop();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::coin_grinder::select_coins;
+    use crate::tests::{build_utxo, Utxo};
+
+    #[derive(Debug)]
+    pub struct ParamsStr<'a> {
+        target: &'a str,
+        change_target: &'a str,
+        max_weight: &'a str,
+        fee_rate: &'a str,
+        weighted_utxos: Vec<&'a str>,
+    }
+
+    fn format_utxo_list(i: &[&Utxo]) -> Vec<String> {
+        i.iter().map(|u| u.value().to_string()).collect()
+    }
+
+    fn build_utxos(weighted_utxos: Vec<&str>) -> Vec<Utxo> {
+        weighted_utxos
+            .iter()
+            .map(|s| {
+                let v: Vec<_> = s.split("/").collect();
+                match v.len() {
+                    2 => {
+                        let a = Amount::from_str(v[0]).unwrap();
+                        let w = Weight::from_wu(v[1].parse().unwrap());
+                        (a, w)
+                    }
+                    1 => {
+                        let a = Amount::from_str(v[0]).unwrap();
+                        (a, Weight::ZERO)
+                    }
+                    _ => panic!(),
+                }
+            })
+            .map(|(a, w)| build_utxo(a, w))
+            .collect()
+    }
+
+    fn assert_coin_select_params(
+        p: &ParamsStr,
+        expected_iterations: u32,
+        expected_inputs: Option<&[&str]>,
+    ) {
+        let fee_rate = p.fee_rate.parse::<u64>().unwrap(); // would be nice if  FeeRate had
+                                                           //from_str like Amount::from_str()
+        let target = Amount::from_str(p.target).unwrap();
+        let change_target = Amount::from_str(p.change_target).unwrap();
+        let fee_rate = FeeRate::from_sat_per_vb(fee_rate).unwrap();
+        let max_weight = Weight::from_str(p.max_weight).unwrap();
+
+        let w_utxos: Vec<_> = build_utxos(p.weighted_utxos.clone());
+
+        let result = select_coins(target, change_target, max_weight, fee_rate, &w_utxos);
+
+        if expected_inputs.is_none() {
+            assert!(result.is_none());
+        } else {
+            let (iteration_count, iter) = result.unwrap();
+            assert_eq!(iteration_count, expected_iterations);
+            let inputs: Vec<_> = iter.collect();
+            let expected_str_list: Vec<String> = expected_inputs
+                .unwrap()
+                .iter()
+                .map(|s| Amount::from_str(s).unwrap().to_string())
+                .collect();
+            let input_str_list: Vec<String> = format_utxo_list(&inputs);
+            assert_eq!(input_str_list, expected_str_list);
+        }
+    }
+
+    #[test]
+    fn min_tail_weight() {
+        let weighted_utxos = vec!["29 sats/36", "19 sats/40", "11 sats/44"];
+
+        let utxos: Vec<_> = build_utxos(weighted_utxos);
+        let eff_values: Vec<(Amount, &Utxo)> = calc_effective_values(&utxos, FeeRate::ZERO);
+        let min_tail_weight = build_min_tail_weight(eff_values.clone());
+
+        let expect: Vec<Weight> =
+            [40u64, 44u64, 18446744073709551615u64].iter().map(|w| Weight::from_wu(*w)).collect();
+        assert_eq!(min_tail_weight, expect);
+    }
+
+    #[test]
+    fn lookahead() {
+        let weighted_utxos = vec!["10 sats/8", "7 sats/4", "5 sats/4", "4 sats/8"];
+
+        let utxos: Vec<_> = build_utxos(weighted_utxos);
+        let eff_values: Vec<(Amount, &Utxo)> = calc_effective_values(&utxos, FeeRate::ZERO);
+        let available_value = Amount::from_str("26 sats").unwrap();
+        let lookahead = build_lookahead(eff_values, available_value);
+
+        let expect: Vec<Amount> = ["16 sats", "9 sats", "4 sats", "0 sats"]
+            .iter()
+            .map(|s| Amount::from_str(s).unwrap())
+            .collect();
+
+        assert_eq!(lookahead, expect);
+    }
+
+    #[test]
+    fn example_solution() {
+        let params = ParamsStr {
+            target: "11 sats",
+            change_target: "0",
+            max_weight: "100",
+            fee_rate: "0",
+            weighted_utxos: vec!["10 sats/8", "7 sats/4", "5 sats/4", "4 sats/8"],
+        };
+
+        assert_coin_select_params(&params, 8, Some(&["7 sats", "5 sats"]));
+    }
+
+    #[test]
+    fn insufficient_funds() {
+        // 1) Insufficient funds, select all provided coins and fail
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1135
+        let params = ParamsStr {
+            target: "49.5 BTC",
+            change_target: "1000000 sats",
+            max_weight: "10000",
+            fee_rate: "0",
+            weighted_utxos: vec!["1 BTC/0", "2 BTC/0"],
+        };
+
+        assert_coin_select_params(&params, 0, None);
+    }
+
+    #[test]
+    fn max_weight_exceeded() {
+        // 2) Test max weight exceeded
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1153
+        let mut wu = Vec::new();
+        for _i in 0..10 {
+            wu.push("1 BTC/272");
+            wu.push("2 BTC/272");
+        }
+
+        let params = ParamsStr {
+            target: "29.5 BTC",
+            change_target: "1000000 sats",
+            max_weight: "3000",
+            fee_rate: "5",
+            weighted_utxos: wu,
+        };
+
+        assert_coin_select_params(&params, 0, None);
+    }
+
+    #[test]
+    fn max_weight_with_result() {
+        // 3 Test that the lowest-weight solution is found when some combinations would exceed the allowed weight
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1171
+        let mut coins = Vec::new();
+        for _i in 0..60 {
+            coins.push("0.33 BTC/272");
+        }
+        for _i in 0..10 {
+            coins.push("2 BTC/272");
+        }
+
+        let params = ParamsStr {
+            target: "25.33 BTC",
+            change_target: "1000000 sats",
+            max_weight: "10000",
+            fee_rate: "5",
+            weighted_utxos: coins,
+        };
+
+        let mut expected = Vec::new();
+        for _i in 0..10 {
+            expected.push("2 BTC");
+        }
+        for _i in 0..17 {
+            expected.push("0.33 BTC");
+        }
+
+        assert_coin_select_params(&params, 100000, Some(&expected));
+    }
+
+    #[test]
+    fn select_lighter_utxos() {
+        // 4) Test that two less valuable UTXOs with a combined lower weight are preferred over a more valuable heavier UTXO
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1193
+        let params = ParamsStr {
+            target: "1.9 BTC",
+            change_target: "1000000 sats",
+            max_weight: "400000",
+            fee_rate: "5",
+            weighted_utxos: vec!["2 BTC/592", "1 BTC/272", "1 BTC/272"],
+        };
+
+        assert_coin_select_params(&params, 4, Some(&["1 BTC", "1 BTC"]));
+    }
+
+    #[test]
+    fn select_best_weight() {
+        // 5) Test finding a solution in a UTXO pool with mixed weights
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1215
+        let coins = vec![
+            "1 BTC/600",
+            "2 BTC/1000",
+            "3 BTC/1400",
+            "4 BTC/600",
+            "5 BTC/1000",
+            "6 BTC/1400",
+            "7 BTC/600",
+            "8 BTC/1000",
+            "9 BTC/1400",
+            "10 BTC/600",
+            "11 BTC/1000",
+            "12 BTC/1400",
+            "13 BTC/600",
+            "14 BTC/1000",
+            "15 BTC/1400",
+        ];
+
+        let params = ParamsStr {
+            target: "30 BTC",
+            change_target: "1000000 sats",
+            max_weight: "400000",
+            fee_rate: "5",
+            weighted_utxos: coins,
+        };
+
+        assert_coin_select_params(&params, 218, Some(&["14 BTC", "13 BTC", "4 BTC"]));
+    }
+
+    #[test]
+    fn lightest_among_many_clones() {
+        // 6) Test that the lightest solution among many clones is found
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1244
+        let mut coins = vec!["4 BTC/400", "3 BTC/400", "2 BTC/400", "1 BTC/400"];
+
+        for _i in 0..100 {
+            coins.push("8 BTC/4000");
+            coins.push("7 BTC/3200");
+            coins.push("6 BTC/2400");
+            coins.push("5 BTC/1600");
+        }
+
+        let params = ParamsStr {
+            target: "989999999 sats",
+            change_target: "1000000 sats",
+            max_weight: "400000",
+            fee_rate: "5",
+            weighted_utxos: coins,
+        };
+
+        let expected = vec!["4 BTC", "3 BTC", "2 BTC", "1 BTC"];
+
+        assert_coin_select_params(&params, 82307, Some(&expected));
+    }
+
+    #[test]
+    fn skip_tiny_inputs() {
+        // 7) Test that lots of tiny UTXOs can be skipped if they are too heavy while there are enough funds in lookahead
+        // https://github.com/bitcoin/bitcoin/blob/43e71f74988b2ad87e4bfc0e1b5c921ab86ec176/src/wallet/test/coinselector_tests.cpp#L1153
+        let mut coins = vec!["1.8 BTC/10000", "1 BTC/4000", "1 BTC/4000"];
+        let mut tiny_coins = vec![];
+        for i in 0..100 {
+            tiny_coins.push(0.01 * 100000000_f64 + i as f64);
+        }
+        let tiny_coins: Vec<String> =
+            tiny_coins.iter().map(|a| format!("{} sats/440", a)).collect();
+        let mut tiny_coins: Vec<&str> = tiny_coins.iter().map(|s| s as &str).collect();
+        coins.append(&mut tiny_coins);
+
+        let params = ParamsStr {
+            target: "1.9 BTC",
+            change_target: "1000000 sats",
+            max_weight: "400000",
+            fee_rate: "5",
+            weighted_utxos: coins,
+        };
+
+        let expected = vec!["1.8 BTC", "1 BTC"];
+
+        assert_coin_select_params(&params, 100000, Some(&expected));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
 
 #[cfg(test)]
 mod tests {
-    use arbitrary::{Arbitrary, Unstructured, Result};
+    use arbitrary::{Arbitrary, Result, Unstructured};
     use arbtest::arbtest;
     use bitcoin::amount::CheckedSum;
     use bitcoin::transaction::effective_value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod branch_and_bound;
+mod coin_grinder;
 mod single_random_draw;
 
 use bitcoin::{Amount, FeeRate, SignedAmount, Weight};
@@ -93,6 +94,23 @@ pub fn select_coins<Utxo: WeightedUtxo>(
     } else {
         select_coins_srd(target, fee_rate, weighted_utxos, &mut thread_rng())
     }
+}
+
+/// DFS-based selection algorithm which optimizes for transaction weight creating a change output.
+pub fn coin_grinder<Utxo: WeightedUtxo>(
+    target: Amount,
+    change_target: Amount,
+    max_selection_weight: Weight,
+    fee_rate: FeeRate,
+    weighted_utxos: &[Utxo],
+) -> Option<(u32, std::vec::IntoIter<&Utxo>)> {
+    coin_grinder::select_coins(
+        target,
+        change_target,
+        max_selection_weight,
+        fee_rate,
+        weighted_utxos,
+    )
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,20 +60,13 @@ pub trait WeightedUtxo {
         effective_value(fee_rate, self.weight(), self.value())
     }
 
-    /// Computes the fee to spend this `Utxo`.
-    ///
-    /// The fee is calculated as: fee rate * (satisfaction_weight + the base weight).
-    fn calculate_fee(&self, fee_rate: FeeRate) -> Option<Amount> {
-        fee_rate.checked_mul_by_weight(self.weight())
-    }
-
     /// Computes how wastefull it is to spend this `Utxo`
     ///
     /// The waste is the difference of the fee to spend this `Utxo` now compared with the expected
     /// fee to spend in the future (long_term_fee_rate).
     fn waste(&self, fee_rate: FeeRate, long_term_fee_rate: FeeRate) -> Option<SignedAmount> {
-        let fee: SignedAmount = self.calculate_fee(fee_rate)?.to_signed().ok()?;
-        let lt_fee: SignedAmount = self.calculate_fee(long_term_fee_rate)?.to_signed().ok()?;
+        let fee: SignedAmount = fee_rate.fee_wu(self.weight())?.to_signed().ok()?;
+        let lt_fee: SignedAmount = long_term_fee_rate.fee_wu(self.weight())?.to_signed().ok()?;
         fee.checked_sub(lt_fee)
     }
 }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -92,7 +92,6 @@ mod tests {
     use crate::WeightedUtxo;
 
     const FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(10);
-    const SATISFACTION_WEIGHT: Weight = Weight::from_wu(204);
 
     #[derive(Debug)]
     pub struct ParamsStr<'a> {
@@ -107,7 +106,7 @@ mod tests {
         let mut pool = vec![];
 
         for a in amts {
-            let utxo = build_utxo(a, SATISFACTION_WEIGHT);
+            let utxo = build_utxo(a, Weight::ZERO);
             pool.push(utxo);
         }
 

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -7,7 +7,7 @@
 use bitcoin::{Amount, FeeRate};
 use rand::seq::SliceRandom;
 
-use crate::{effective_value, WeightedUtxo, CHANGE_LOWER};
+use crate::{WeightedUtxo, CHANGE_LOWER};
 
 /// Randomly select coins for the given target by shuffling the UTXO pool and
 /// taking UTXOs until the given target is reached.
@@ -59,9 +59,7 @@ pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
     let mut value = Amount::ZERO;
 
     for w_utxo in origin {
-        let utxo_value = w_utxo.value();
-        let utxo_weight = w_utxo.satisfaction_weight();
-        let effective_value = effective_value(fee_rate, utxo_weight, utxo_value);
+        let effective_value = w_utxo.effective_value(fee_rate);
 
         if let Some(e) = effective_value {
             if let Ok(v) = e.to_unsigned() {

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -208,21 +208,26 @@ mod tests {
 
     #[test]
     fn select_coins_skip_negative_effective_value() {
+        // A value of 2 cBTC is needed after CHANGE_LOWER is subtracted.
+        // After randomization, the effective values are: [1,9 cBTC, -2 sats, 0.1 cBTC]
+        // The middle utxo is skipped since it's effective value is negative.
         let params = ParamsStr {
-            target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
+            target: "1.95 cBTC",
             fee_rate: "10",
-            weighted_utxos: vec!["1 cBTC", "2 cBTC", "1 sat/204"], // 1 sat @ 204 wu has negative effective_value
+            weighted_utxos: vec!["0.1 cBTC", "1.9 cBTC", "1 sat/204"],
         };
 
-        assert_coin_select_params(&params, Some(&["2 cBTC", "1 cBTC"]));
+        assert_coin_select_params(&params, Some(&["1.9 cBTC", "0.1 cBTC"]));
     }
 
     #[test]
     fn select_coins_srd_fee_rate_error() {
+        // Setting very high FeeRate of u64::MAX causes the effective_value to overflow
+        // returning None.
         let params = ParamsStr {
             target: "1 cBTC",
             fee_rate: "18446744073709551615",
-            weighted_utxos: vec!["1 cBTC", "2 cBTC"],
+            weighted_utxos: vec!["1 cBTC/204", "2 cBTC/204"],
         };
 
         assert_coin_select_params(&params, None);

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -4,11 +4,10 @@
 //!
 //! This module introduces the Single Random Draw Coin-Selection Algorithm.
 
-use bitcoin::blockdata::transaction::effective_value;
 use bitcoin::{Amount, FeeRate};
 use rand::seq::SliceRandom;
 
-use crate::{WeightedUtxo, CHANGE_LOWER};
+use crate::{effective_value, WeightedUtxo, CHANGE_LOWER};
 
 /// Randomly select coins for the given target by shuffling the UTXO pool and
 /// taking UTXOs until the given target is reached.


### PR DESCRIPTION
Add Coin Grinder, A Rust DFS-based selection algorithm which optimizes for transaction
weight and creates a change output.

This is a Rust implementation of the C++ version https://github.com/bitcoin/bitcoin/pull/27877

I plan to follow up and add fuzz tests, property tests and benchmarks before a release.  While i've made a best attempt to guard against possible overflows by using checked arithmetic, I suspect more will be uncovered once fuzz tests are added.  Every instance of checked arithmetic slows the performance, therefore I've left places unchecked for now that are not obvious.