### PR TITLE
Add iteration count

### DIFF
--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -34,19 +34,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("bnb 1000", |b| {
         b.iter(|| {
-            let result: Vec<_> = select_coins_bnb(
+            let (iteration_count, inputs_iter) = select_coins_bnb(
                 black_box(target),
                 black_box(cost_of_change),
                 black_box(FeeRate::ZERO),
                 black_box(FeeRate::ZERO),
                 black_box(&utxo_pool),
             )
-            .unwrap()
-            .collect();
+            .unwrap();
+            assert_eq!(iteration_count, 100000);
+            let inputs: Vec<_> = inputs_iter.collect();
 
-            assert_eq!(2, result.len());
-            assert_eq!(Amount::from_sat(1_000), result[0].value());
-            assert_eq!(Amount::from_sat(3), result[1].value());
+            assert_eq!(2, inputs.len());
+            assert_eq!(Amount::from_sat(1_000), inputs[0].value());
+            assert_eq!(Amount::from_sat(3), inputs[1].value());
         })
     });
 }

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -161,7 +161,7 @@ pub fn select_coins_bnb<Utxo: WeightedUtxo>(
 ) -> Option<IntoIter<&Utxo>> {
     // Total_Tries in Core:
     // https://github.com/bitcoin/bitcoin/blob/1d9da8da309d1dbf9aef15eb8dc43b4a2dc3d309/src/wallet/coinselection.cpp#L74
-    const ITERATION_LIMIT: i32 = 100_000;
+    const ITERATION_LIMIT: u32 = 100_000;
 
     let mut iteration = 0;
     let mut index = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,6 @@ pub fn select_coins<Utxo: WeightedUtxo>(
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-
     use arbitrary::{Arbitrary, Result, Unstructured};
     use arbtest::arbtest;
     use bitcoin::amount::CheckedSum;


### PR DESCRIPTION
When refactoring or applying changes, testing the iteration count helps to catch inadvertent changes to the core algorithm competency.  Also, coin-grinder implements an iteration count, so this helps to unify the interface between the various selection algorithms.

A side note on this implementation is that if the algorithm returns None for results, then no iteration count is returned.  I'd like to
change this however it would make sense to change this when I remove the None type return and replace it with more verbose error messaging.  For now, in all tests that expect a None return, the test asserts the iteration count is zero.