### PR TITLE
Add install instructions for cargo fuzz

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The following fuzz tests can then be run:
 
 ## Property tests
 
-To continuously run the proptests:
+This project has a number of property tests created using [arbtest](https://github.com/matklad/arbtest).  The property tests build a random pool of UTXOs and random selection parameters and then assert the results are correct.  To continuously run only the property tests, a simple shell script runs them in a loop.
+
+To continuously run the property tests:
 ```
 > run_proptests.sh
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The current interface is provided via `select_coins()` function.  The required p
 
 As discussed in the literature above, we want to find a "changeless" solution.  A changeless solution is one that exceeds the `target` however is less than `target` + `cost_of_change`.  If no changeless solution can be found, then creating a change output by splitting a UTXO is the next best outcome.  To that end, `select_coins()` initially attempts a Branch and Bound selection algorithm to find a changeless solution.  If no changeless solution is found, then `select_coins()` falls back to a Single Random Draw selection strategy.
 
-## Fuzz
+## Fuzz tests
 
 To run fuzz tests, install [cargo fuzz](https://crates.io/crates/cargo-fuzz).
 
@@ -26,7 +26,7 @@ The following fuzz tests can then be run:
 > cargo fuzz run select_coins
 ```
 
-## Proptest
+## Property tests
 
 To continuously run the proptests:
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To continuously run the property tests:
 
 ## Benchmarks
 
+Benchmarks for the `Branch and Bound Selection` algorithm are written using [Criterion]( https://github.com/bheisler/criterion.rs).  This is useful for testing new changes and performance optimizations.
+
 To run the benchmarks use: 
 ```
 > cargo bench

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ As discussed in the literature above, we want to find a "changeless" solution.  
 
 ## Fuzz
 
-Fuzz with `cargo fuzz run select_coins_srd`, `cargo fuzz run select_coins_bnb` or `cargo fuzz run select_coins`.
+To run fuzz tests, install [cargo fuzz](https://crates.io/crates/cargo-fuzz).
+
+The following fuzz tests can then be run:
+```
+> cargo fuzz run select_coins_srd
+> cargo fuzz run select_coins_bnb
+> cargo fuzz run select_coins
+```
 
 ## Proptest
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ The following fuzz tests can then be run:
 
 ## Proptest
 
-To continuously run the proptests: `run_proptests.sh`
+To continuously run the proptests:
+```
+> run_proptests.sh
+```
 
 ## Benchmarks
 
-To run the benchmarks use: `cargo bench`.
+To run the benchmarks use: 
+```
+> cargo bench
+```
 
 Note: criterion requires rustc version 1.65 to run the benchmarks.
 


### PR DESCRIPTION
Update docs to make them less terrible:

* Add install instruction for cargo fuzz to README
* Improve header titles
* stylize terminal commands
* fill out description section for property tests and fuzz tests