### PR TITLE
Return vector instead of iterator

### DIFF
--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -34,7 +34,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("bnb 1000", |b| {
         b.iter(|| {
-            let (iteration_count, inputs_iter) = select_coins_bnb(
+            let (iteration_count, inputs) = select_coins_bnb(
                 black_box(target),
                 black_box(cost_of_change),
                 black_box(FeeRate::ZERO),
@@ -43,7 +43,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             )
             .unwrap();
             assert_eq!(iteration_count, 100000);
-            let inputs: Vec<_> = inputs_iter.collect();
 
             assert_eq!(2, inputs.len());
             assert_eq!(Amount::from_sat(1_000), inputs[0].value());

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -806,7 +806,7 @@ mod tests {
                         assert_eq!(amount_sum, target);
                     } else {
                         // if result was none, then assert that fail happened because overflow when
-                        // ssumming pool.  In the future, assert specific error when added.
+                        // summing pool.  In the future, assert specific error when added.
                         let available_value = utxos.into_iter().map(|u| u.value()).checked_sum();
                         assert!(available_value.is_none());
                     }


### PR DESCRIPTION
An earlier implementation called collect() before returning the results. Instead of calling collect(), the API was changed to just return the iterator since it's possible dependant applications may prefer to use the iterator.  However, after a refactor, the call to collect() was removed, and now it no longer makes sense to return an iterator. Furthermore, return an opaque type makes for a more complicated return type, making it hard to alias for example.  Returning a concrete type therefore simplifies the API.