### PR TITLE
Make type interface more generic

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -150,13 +150,14 @@ use crate::WeightedUtxo;
 //
 // If either 1 or 2 is true, we consider the current search path no longer viable to continue.  In
 // such a case, backtrack to start a new search path.
-pub fn select_coins_bnb<Utxo: WeightedUtxo>(
+
+pub fn select_coins_bnb<'a, Utxo: WeightedUtxo, I: IntoIterator<Item = &'a Utxo>>(
     target: Amount,
     cost_of_change: Amount,
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
-    weighted_utxos: &[Utxo],
-) -> Option<(u32, Vec<&Utxo>)> {
+    weighted_utxos: I,
+) -> Option<(u32, Vec<&'a Utxo>)> {
     // Total_Tries in Core:
     // https://github.com/bitcoin/bitcoin/blob/1d9da8da309d1dbf9aef15eb8dc43b4a2dc3d309/src/wallet/coinselection.cpp#L74
     const ITERATION_LIMIT: u32 = 100_000;
@@ -177,7 +178,7 @@ pub fn select_coins_bnb<Utxo: WeightedUtxo>(
 
     // Creates a tuple of (effective_value, waste, weighted_utxo)
     let mut w_utxos: Vec<(Amount, SignedAmount, &Utxo)> = weighted_utxos
-        .iter()
+        .into_iter()
         // calculate effective_value and waste for each w_utxo.
         .map(|wu| (wu.effective_value(fee_rate), wu.waste(fee_rate, long_term_fee_rate), wu))
         // remove utxos that either had an error in the effective_value or waste calculation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,20 +87,20 @@ pub trait WeightedUtxo {
 /// Requires compilation with the "rand" feature.
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-pub fn select_coins<Utxo: WeightedUtxo>(
+pub fn select_coins<'a, Utxo: WeightedUtxo, I: IntoIterator<Item = &'a Utxo>>(
     target: Amount,
     cost_of_change: Amount,
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
-    weighted_utxos: &[Utxo],
-) -> Option<(u32, Vec<&Utxo>)> {
-    let bnb =
-        select_coins_bnb(target, cost_of_change, fee_rate, long_term_fee_rate, weighted_utxos);
+    weighted_utxos: I,
+) -> Option<(u32, Vec<&'a Utxo>)> {
+    let v: Vec<&Utxo> = weighted_utxos.into_iter().collect();
+    let result = select_coins_bnb(target, cost_of_change, fee_rate, long_term_fee_rate, v.clone());
 
-    if bnb.is_some() {
-        bnb
+    if result.is_some() {
+        result
     } else {
-        select_coins_srd(target, fee_rate, weighted_utxos, &mut thread_rng())
+        select_coins_srd(target, fee_rate, v, &mut thread_rng())
     }
 }
 

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -40,17 +40,17 @@ use crate::{WeightedUtxo, CHANGE_LOWER};
 /// * `None` un-expected results during search.  A future implementation can replace all `None`
 ///   returns with a more informative error.  Example of error: iteration limit hit, overflow
 ///   when summing the UTXO space, Not enough potential amount to meet the target, etc.
-pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
+pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo, I: IntoIterator<Item = &'a Utxo>>(
     target: Amount,
     fee_rate: FeeRate,
-    weighted_utxos: &'a [Utxo],
+    weighted_utxos: I,
     rng: &mut R,
 ) -> Option<(u32, Vec<&'a Utxo>)> {
     if target > Amount::MAX_MONEY {
         return None;
     }
 
-    let mut result: Vec<_> = weighted_utxos.iter().collect();
+    let mut result: Vec<&Utxo> = weighted_utxos.into_iter().collect();
     let mut origin = result.to_owned();
     origin.shuffle(rng);
 


### PR DESCRIPTION
Accept any type param which has the trait into_iter().  The includes Vec or anything that can iterate over &UTXOs.