### PR TITLE
bug: test: Add panic when no results found

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -392,6 +392,8 @@ mod tests {
 
             let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str.unwrap());
             assert_ref_eq(inputs, expected.utxos);
+        } else {
+            assert!(expected_inputs_str.is_none());
         }
     }
 
@@ -456,6 +458,30 @@ mod tests {
     #[test]
     fn select_coins_bnb_ten() {
         assert_coin_select("10 cBTC", 8, &["4 cBTC", "3 cBTC", "2 cBTC", "1 cBTC"]);
+    }
+
+    #[test]
+    #[should_panic]
+    // the target is greater than the sum of available UTXOs.
+    // therefore asserting that a selection exists should panic.
+    fn select_coins_bnb_eleven_invalid_target_should_panic() {
+        assert_coin_select("11 cBTC", 8, &["1 cBTC"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn select_coins_bnb_params_invalid_target_should_panic() {
+        // the target is greater than the sum of available UTXOs.
+        // therefore asserting that a selection exists should panic.
+        let params = ParamsStr {
+            target: "11 cBTC",
+            cost_of_change: "1 cBTC",
+            fee_rate: "0",
+            lt_fee_rate: "0",
+            weighted_utxos: vec!["1.5 cBTC"],
+        };
+
+        assert_coin_select_params(&params, 2, Some(&["1.5 cBTC"]));
     }
 
     #[test]

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -138,6 +138,8 @@ mod tests {
 
             let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str.unwrap());
             assert_ref_eq(inputs, expected.utxos);
+        } else {
+            assert!(expected_inputs_str.is_none());
         }
     }
 
@@ -163,6 +165,25 @@ mod tests {
     #[test]
     fn select_coins_srd_all_solution() {
         assert_coin_select("2.5 cBTC", 2, &["2 cBTC/204 wu", "1 cBTC/204 wu"]);
+    }
+
+    #[test]
+    #[should_panic]
+    // the target is greater than the sum of available UTXOs.
+    // therefore asserting that a selection exists should panic.
+    fn select_coins_srd_eleven_invalid_target_should_panic() {
+        assert_coin_select("11 cBTC", 8, &["1 cBTC"]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn select_coins_srd_params_invalid_target_should_panic() {
+        // the target is greater than the sum of available UTXOs.
+        // therefore asserting that a selection exists should panic.
+        let params =
+            ParamsStr { target: "11 cBTC", fee_rate: "0", weighted_utxos: vec!["1.5 cBTC"] };
+
+        assert_coin_select_params(&params, 2, Some(&["1.5 cBTC"]));
     }
 
     #[test]


### PR DESCRIPTION
If the test framework asserts that a result can be found, and yet there isn't a result found, the tests should panic.  This subtle bug in the test framework was introduced in a recent commit:

https://github.com/yancyribbens/rust-bitcoin-coin-selection/commit/780d14e95c55cf785093107480e94e2f8adcc471