### PR TITLE
refactor: Call helper function

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -345,25 +345,19 @@ mod tests {
         weighted_utxos: Vec<&'a str>,
     }
 
-    fn build_pool() -> UtxoPool {
-        let utxo_str_list = vec!["1 cBTC", "2 cBTC", "3 cBTC", "4 cBTC"];
-        UtxoPool::from_str_list(&utxo_str_list)
-    }
-
     fn assert_coin_select(
         target_str: &str,
         expected_iterations: u32,
         expected_inputs_str: &[&str],
     ) {
-        let target = Amount::from_str(target_str).unwrap();
-        let pool = build_pool();
-        let (iterations, inputs) =
-            select_coins_bnb(target, Amount::ZERO, FeeRate::ZERO, FeeRate::ZERO, &pool.utxos)
-                .unwrap();
-        assert_eq!(iterations, expected_iterations);
-
-        let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str);
-        assert_ref_eq(inputs, expected.utxos);
+        let p = ParamsStr {
+            target: target_str,
+            cost_of_change: "0",
+            fee_rate: "0",
+            lt_fee_rate: "0",
+            weighted_utxos: vec!["1 cBTC", "2 cBTC", "3 cBTC", "4 cBTC"],
+        };
+        assert_coin_select_params(&p, expected_iterations, Some(expected_inputs_str));
     }
 
     fn assert_coin_select_params(

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -88,18 +88,11 @@ mod tests {
     use crate::single_random_draw::select_coins_srd;
     use crate::tests::{assert_proptest_srd, assert_ref_eq, UtxoPool};
 
-    const FEE_RATE: FeeRate = FeeRate::from_sat_per_kwu(10);
-
     #[derive(Debug)]
     pub struct ParamsStr<'a> {
         target: &'a str,
         fee_rate: &'a str,
         weighted_utxos: Vec<&'a str>,
-    }
-
-    fn build_pool() -> UtxoPool {
-        let utxo_str_list = vec!["1 cBTC/204 wu", "2 cBTC/204 wu"];
-        UtxoPool::from_str_list(&utxo_str_list)
     }
 
     fn get_rng() -> StepRng {
@@ -148,15 +141,12 @@ mod tests {
         expected_iterations: u32,
         expected_inputs_str: &[&str],
     ) {
-        let target = Amount::from_str(target_str).unwrap();
-        let pool = build_pool();
-
-        let (iterations, inputs) =
-            select_coins_srd(target, FEE_RATE, &pool.utxos, &mut get_rng()).unwrap();
-        assert_eq!(iterations, expected_iterations);
-
-        let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str);
-        assert_ref_eq(inputs, expected.utxos);
+        let p = ParamsStr {
+            target: target_str,
+            fee_rate: "10",
+            weighted_utxos: vec!["1 cBTC/204 wu", "2 cBTC/204 wu"],
+        };
+        assert_coin_select_params(&p, expected_iterations, Some(expected_inputs_str));
     }
 
     #[test]


### PR DESCRIPTION
`assert_coin_select()` uses default settings minimizing the number of arguments needed.  `assert_coin_select_params()` takes a struct of parameters which is more customizable.  However, both asserts are independently calling the search function, building a utxo pool, parsing arguments and asserting results.  By calling the more robust `assert_coin_select_params()` from within `assert_coin_select()`, the line count is reduced by consolidating duplicate functionality.

Remove the `FEE_RATE` const since now the fee_rate for the test is used in one place when creating the params to be passed to `asswert_coin_select_params()`.

Remove `build_pool()` for the same reason as removing `FEE_RATE` const since this is defined in the params now.