### PR TITLE
Add effective_value assertions

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -337,7 +337,7 @@ mod tests {
     const TX_IN_BASE_WEIGHT: u64 = 160;
 
     #[derive(Debug)]
-    pub struct ParamsStr<'a> {
+    pub struct TestBnB<'a> {
         target: &'a str,
         cost_of_change: &'a str,
         fee_rate: &'a str,
@@ -345,7 +345,7 @@ mod tests {
         weighted_utxos: Vec<&'a str>,
     }
 
-    impl ParamsStr<'_> {
+    impl TestBnB<'_> {
         fn assert(&self, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
             // Remove this check once iteration count is returned by error
             if expected_inputs_str.is_none() {
@@ -378,7 +378,7 @@ mod tests {
         expected_iterations: u32,
         expected_inputs_str: &[&str],
     ) {
-        ParamsStr {
+        TestBnB {
             target: target_str,
             cost_of_change: "0",
             fee_rate: "0",
@@ -464,7 +464,7 @@ mod tests {
     fn select_coins_bnb_params_invalid_target_should_panic() {
         // the target is greater than the sum of available UTXOs.
         // therefore asserting that a selection exists should panic.
-        ParamsStr {
+        TestBnB {
             target: "11 cBTC",
             cost_of_change: "1 cBTC",
             fee_rate: "0",
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_zero() {
-        ParamsStr {
+        TestBnB {
             target: "0",
             cost_of_change: "0",
             fee_rate: "0",
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_cost_of_change() {
-        let mut p = ParamsStr {
+        let mut p = TestBnB {
             target: "1 cBTC",
             cost_of_change: "1 cBTC",
             fee_rate: "0",
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_effective_value() {
-        ParamsStr {
+        TestBnB {
             target: "1 cBTC",
             cost_of_change: "0",
             fee_rate: "10 sat/kwu",
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_skip_effective_negative_effective_value() {
-        ParamsStr {
+        TestBnB {
             target: "1 cBTC",
             cost_of_change: "1 cBTC",
             fee_rate: "10 sat/kwu",
@@ -528,7 +528,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_target_greater_than_value() {
-        ParamsStr {
+        TestBnB {
             target: "11 cBTC",
             cost_of_change: "0",
             fee_rate: "0",
@@ -540,7 +540,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_consume_more_inputs_when_cheap() {
-        ParamsStr {
+        TestBnB {
             target: "6 sats",
             cost_of_change: "0",
             fee_rate: "10 sat/kwu",
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_consume_less_inputs_when_expensive() {
-        ParamsStr {
+        TestBnB {
             target: "6 sats",
             cost_of_change: "0",
             fee_rate: "20 sat/kwu",
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_consume_less_inputs_with_excess_when_expensive() {
-        ParamsStr {
+        TestBnB {
             target: "6 sats",
             cost_of_change: "1 sats",
             fee_rate: "20 sat/kwu",
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_utxo_pool_sum_overflow() {
-        ParamsStr {
+        TestBnB {
             target: "1 cBTC",
             cost_of_change: "0",
             fee_rate: "0",
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_upper_bound_overflow() {
-        ParamsStr {
+        TestBnB {
             target: "1 sats",
             cost_of_change: "18446744073709551615 sats", // u64::MAX
             fee_rate: "0",
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_utxo_greater_than_max_money() {
-        ParamsStr {
+        TestBnB {
             target: "1 sats",
             cost_of_change: "18141417255681066410 sats",
             fee_rate: "1 sat/kwu",
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_set_size_five() {
-        ParamsStr {
+        TestBnB {
             target: "6 cBTC",
             cost_of_change: "0",
             fee_rate: "0",
@@ -624,7 +624,7 @@ mod tests {
 
     #[test]
     fn select_coins_bnb_set_size_seven() {
-        ParamsStr {
+        TestBnB {
             target: "18 cBTC",
             cost_of_change: "50 sats",
             fee_rate: "0",
@@ -655,7 +655,7 @@ mod tests {
         for _i in 0..50_000 {
             utxos.push("5 cBTC");
         }
-        ParamsStr {
+        TestBnB {
             target: "30 cBTC",
             cost_of_change: "5000 sats",
             fee_rate: "0",

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -31,7 +31,7 @@ use crate::{Return, WeightedUtxo};
 /// # Returns
 ///
 /// * `Some((u32, Vec<WeightedUtxo>))` where `Vec<WeightedUtxo>` is non-empty and where u32 is the
-///    iteration count.  The search result succeeded and a match was found.
+///   iteration count.  The search result succeeded and a match was found.
 /// * `None` un-expected results OR no match found.  A future implementation can add Error types
 ///   which will differentiate between an unexpected error and no match found.  Currently, a None
 ///   type occurs when one or more of the following criteria are met:

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -347,11 +347,6 @@ mod tests {
 
     impl TestBnB<'_> {
         fn assert(&self, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
-            // Remove this check once iteration count is returned by error
-            if expected_inputs_str.is_none() {
-                assert_eq!(0, expected_iterations);
-            }
-
             let target = Amount::from_str(self.target).unwrap();
             let cost_of_change = Amount::from_str(self.cost_of_change).unwrap();
 
@@ -369,6 +364,8 @@ mod tests {
                 assert_ref_eq(inputs, expected.utxos);
             } else {
                 assert!(expected_inputs_str.is_none());
+                // Remove this check once iteration count is returned by error
+                assert_eq!(0, expected_iterations);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub trait WeightedUtxo {
 /// # Returns
 ///
 /// * `Some((u32, Vec<WeightedUtxo>))` where `Vec<WeightedUtxo>` is non-empty and where u32 is the
-///    iteration count of the prevailing algorithm.  The search result succeeded and a match found.
+///   iteration count of the prevailing algorithm.  The search result succeeded and a match found.
 /// * `None` if un-expected results OR no match found.  A future implementation can add Error types
 ///   which will differentiate between an unexpected error and no match found.  Currently, a None
 ///   type occurs when one or more of the following criteria are met:

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -15,7 +15,7 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 /// # Parameters
 ///
 /// * `target` - target value to send to recipient.  Include the fee to pay for
-///    the known parts of the transaction excluding the fee for the inputs.
+///   the known parts of the transaction excluding the fee for the inputs.
 /// * `fee_rate` - ratio of transaction amount per size.
 /// * `weighted_utxos` - Weighted UTXOs from which to sum the target amount.
 /// * `rng` - used primarily by tests to make the selection deterministic.

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -89,13 +89,13 @@ mod tests {
     use crate::tests::{assert_proptest_srd, assert_ref_eq, parse_fee_rate, UtxoPool};
 
     #[derive(Debug)]
-    pub struct ParamsStr<'a> {
+    pub struct TestSRD<'a> {
         target: &'a str,
         fee_rate: &'a str,
         weighted_utxos: Vec<&'a str>,
     }
 
-    impl ParamsStr<'_> {
+    impl TestSRD<'_> {
         fn assert(&self, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
             // Remove this check once iteration count is returned by error
             if expected_inputs_str.is_none() {
@@ -138,7 +138,7 @@ mod tests {
         expected_iterations: u32,
         expected_inputs_str: &[&str],
     ) {
-        ParamsStr {
+        TestSRD {
             target: target_str,
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/204 wu", "2 cBTC/204 wu"],
@@ -167,19 +167,19 @@ mod tests {
     fn select_coins_srd_params_invalid_target_should_panic() {
         // the target is greater than the sum of available UTXOs.
         // therefore asserting that a selection exists should panic.
-        ParamsStr { target: "11 cBTC", fee_rate: "0", weighted_utxos: vec!["1.5 cBTC"] }
+        TestSRD { target: "11 cBTC", fee_rate: "0", weighted_utxos: vec!["1.5 cBTC"] }
             .assert(2, Some(&["1.5 cBTC"]));
     }
 
     #[test]
     fn select_coins_srd_no_solution() {
-        ParamsStr { target: "4 cBTC", fee_rate: "0", weighted_utxos: vec!["1 cBTC", "2 cBTC"] }
+        TestSRD { target: "4 cBTC", fee_rate: "0", weighted_utxos: vec!["1 cBTC", "2 cBTC"] }
             .assert(0, None);
     }
 
     #[test]
     fn select_coins_skip_negative_effective_value() {
-        ParamsStr {
+        TestSRD {
             target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC", "1 sat/204 wu"], // 1 sat @ 204 has negative effective_value
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_fee_rate_error() {
-        ParamsStr {
+        TestSRD {
             target: "1 cBTC",
             fee_rate: "18446744073709551615 sat/kwu",
             weighted_utxos: vec!["1 cBTC/204 wu", "2 cBTC/204 wu"],
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_change_output_too_small() {
-        ParamsStr {
+        TestSRD {
             target: "3 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC"],
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_with_high_fee() {
-        ParamsStr {
+        TestSRD {
             target: "1.99999 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC"],
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_addition_overflow() {
-        ParamsStr {
+        TestSRD {
             target: "2 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/18446744073709551615 wu"], // weight= u64::MAX
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_threshold_overflow() {
-        ParamsStr {
+        TestSRD {
             target: "18446744073709551615 sat", // u64::MAX
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/18446744073709551615 wu"],
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn select_coins_srd_none_effective_value() {
-        ParamsStr {
+        TestSRD {
             target: ".95 cBTC",
             fee_rate: "0",
             weighted_utxos: vec![

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -97,11 +97,6 @@ mod tests {
 
     impl TestSRD<'_> {
         fn assert(&self, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
-            // Remove this check once iteration count is returned by error
-            if expected_inputs_str.is_none() {
-                assert_eq!(0, expected_iterations);
-            }
-
             let fee_rate = parse_fee_rate(self.fee_rate);
             let target = Amount::from_str(self.target).unwrap();
 
@@ -115,6 +110,8 @@ mod tests {
                 assert_ref_eq(inputs, expected.utxos);
             } else {
                 assert!(expected_inputs_str.is_none());
+                // Remove this check once iteration count is returned by error
+                assert_eq!(0, expected_iterations);
             }
         }
     }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -95,6 +95,30 @@ mod tests {
         weighted_utxos: Vec<&'a str>,
     }
 
+    impl ParamsStr<'_> {
+        fn assert(&self, expected_iterations: u32, expected_inputs_str: Option<&[&str]>) {
+            // Remove this check once iteration count is returned by error
+            if expected_inputs_str.is_none() {
+                assert_eq!(0, expected_iterations);
+            }
+
+            let fee_rate = parse_fee_rate(self.fee_rate);
+            let target = Amount::from_str(self.target).unwrap();
+
+            let pool: UtxoPool = UtxoPool::from_str_list(&self.weighted_utxos);
+            let result = select_coins_srd(target, fee_rate, &pool.utxos, &mut get_rng());
+
+            if let Some((iterations, inputs)) = result {
+                assert_eq!(iterations, expected_iterations);
+
+                let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str.unwrap());
+                assert_ref_eq(inputs, expected.utxos);
+            } else {
+                assert!(expected_inputs_str.is_none());
+            }
+        }
+    }
+
     fn get_rng() -> StepRng {
         // [1, 2]
         // let mut vec: Vec<u32> = (1..3).collect();
@@ -109,43 +133,17 @@ mod tests {
         StepRng::new(0, 0)
     }
 
-    fn assert_coin_select_params(
-        p: &ParamsStr,
-        expected_iterations: u32,
-        expected_inputs_str: Option<&[&str]>,
-    ) {
-        // Remove this check once iteration count is returned by error
-        if expected_inputs_str.is_none() {
-            assert_eq!(0, expected_iterations);
-        }
-
-        let fee_rate = parse_fee_rate(p.fee_rate);
-        let target = Amount::from_str(p.target).unwrap();
-
-        let pool: UtxoPool = UtxoPool::from_str_list(&p.weighted_utxos);
-        let result = select_coins_srd(target, fee_rate, &pool.utxos, &mut get_rng());
-
-        if let Some((iterations, inputs)) = result {
-            assert_eq!(iterations, expected_iterations);
-
-            let expected: UtxoPool = UtxoPool::from_str_list(expected_inputs_str.unwrap());
-            assert_ref_eq(inputs, expected.utxos);
-        } else {
-            assert!(expected_inputs_str.is_none());
-        }
-    }
-
     fn assert_coin_select(
         target_str: &str,
         expected_iterations: u32,
         expected_inputs_str: &[&str],
     ) {
-        let p = ParamsStr {
+        ParamsStr {
             target: target_str,
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/204 wu", "2 cBTC/204 wu"],
-        };
-        assert_coin_select_params(&p, expected_iterations, Some(expected_inputs_str));
+        }
+        .assert(expected_iterations, Some(expected_inputs_str));
     }
 
     #[test]
@@ -169,98 +167,87 @@ mod tests {
     fn select_coins_srd_params_invalid_target_should_panic() {
         // the target is greater than the sum of available UTXOs.
         // therefore asserting that a selection exists should panic.
-        let params =
-            ParamsStr { target: "11 cBTC", fee_rate: "0", weighted_utxos: vec!["1.5 cBTC"] };
-
-        assert_coin_select_params(&params, 2, Some(&["1.5 cBTC"]));
+        ParamsStr { target: "11 cBTC", fee_rate: "0", weighted_utxos: vec!["1.5 cBTC"] }
+            .assert(2, Some(&["1.5 cBTC"]));
     }
 
     #[test]
     fn select_coins_srd_no_solution() {
-        let params =
-            ParamsStr { target: "4 cBTC", fee_rate: "0", weighted_utxos: vec!["1 cBTC", "2 cBTC"] };
-
-        assert_coin_select_params(&params, 0, None);
+        ParamsStr { target: "4 cBTC", fee_rate: "0", weighted_utxos: vec!["1 cBTC", "2 cBTC"] }
+            .assert(0, None);
     }
 
     #[test]
     fn select_coins_skip_negative_effective_value() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC", "1 sat/204 wu"], // 1 sat @ 204 has negative effective_value
-        };
-
-        assert_coin_select_params(&params, 3, Some(&["2 cBTC", "1 cBTC"]));
+        }
+        .assert(3, Some(&["2 cBTC", "1 cBTC"]));
     }
 
     #[test]
     fn select_coins_srd_fee_rate_error() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "1 cBTC",
             fee_rate: "18446744073709551615 sat/kwu",
             weighted_utxos: vec!["1 cBTC/204 wu", "2 cBTC/204 wu"],
-        };
-
-        assert_coin_select_params(&params, 0, None);
+        }
+        .assert(0, None);
     }
 
     #[test]
     fn select_coins_srd_change_output_too_small() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "3 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC"],
-        };
-
-        assert_coin_select_params(&params, 0, None);
+        }
+        .assert(0, None);
     }
 
     #[test]
     fn select_coins_srd_with_high_fee() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "1.99999 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC", "2 cBTC"],
-        };
-
-        assert_coin_select_params(&params, 2, Some(&["2 cBTC", "1 cBTC"]));
+        }
+        .assert(2, Some(&["2 cBTC", "1 cBTC"]));
     }
 
     #[test]
     fn select_coins_srd_addition_overflow() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "2 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/18446744073709551615 wu"], // weight= u64::MAX
-        };
-
-        assert_coin_select_params(&params, 0, None);
+        }
+        .assert(0, None);
     }
 
     #[test]
     fn select_coins_srd_threshold_overflow() {
-        let params = ParamsStr {
+        ParamsStr {
             target: "18446744073709551615 sat", // u64::MAX
             fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC/18446744073709551615 wu"],
-        };
-
-        assert_coin_select_params(&params, 0, None);
+        }
+        .assert(0, None);
     }
 
     #[test]
     fn select_coins_srd_none_effective_value() {
-        let params = ParamsStr {
+        ParamsStr {
             target: ".95 cBTC",
             fee_rate: "0",
             weighted_utxos: vec![
                 "1 cBTC",
                 "9223372036854775808 sat", //i64::MAX + 1
             ],
-        };
-
-        assert_coin_select_params(&params, 2, Some(&["1 cBTC"]));
+        }
+        .assert(2, Some(&["1 cBTC"]));
     }
 
     #[test]


### PR DESCRIPTION
Add ability to create and assert UTXOs by effective_value instead of solely absolute_value.  This follows suit with a similar update to the bitcoin core tests https://github.com/bitcoin/bitcoin/pull/29532.