### PR TITLE
tests: Annotate fee_rate metric

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -331,7 +331,7 @@ mod tests {
     use bitcoin::{Amount, Weight};
 
     use super::*;
-    use crate::tests::{assert_proptest_bnb, assert_ref_eq, Utxo, UtxoPool};
+    use crate::tests::{assert_proptest_bnb, assert_ref_eq, parse_fee_rate, Utxo, UtxoPool};
     use crate::WeightedUtxo;
 
     const TX_IN_BASE_WEIGHT: u64 = 160;
@@ -369,14 +369,12 @@ mod tests {
         if expected_inputs_str.is_none() {
             assert_eq!(0, expected_iterations);
         }
-        let fee_rate = p.fee_rate.parse::<u64>().unwrap(); // would be nice if  FeeRate had
-                                                           // from_str like Amount::from_str()
-        let lt_fee_rate = p.lt_fee_rate.parse::<u64>().unwrap();
 
         let target = Amount::from_str(p.target).unwrap();
         let cost_of_change = Amount::from_str(p.cost_of_change).unwrap();
-        let fee_rate = FeeRate::from_sat_per_kwu(fee_rate);
-        let lt_fee_rate = FeeRate::from_sat_per_kwu(lt_fee_rate);
+
+        let fee_rate = parse_fee_rate(p.fee_rate);
+        let lt_fee_rate = parse_fee_rate(p.lt_fee_rate);
 
         let pool: UtxoPool = UtxoPool::from_str_list(&p.weighted_utxos);
         let result = select_coins_bnb(target, cost_of_change, fee_rate, lt_fee_rate, &pool.utxos);
@@ -512,8 +510,8 @@ mod tests {
         let params = ParamsStr {
             target: "1 cBTC",
             cost_of_change: "0",
-            fee_rate: "10",
-            lt_fee_rate: "10",
+            fee_rate: "10 sat/kwu",
+            lt_fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1 cBTC"],
         };
 
@@ -525,8 +523,8 @@ mod tests {
         let params = ParamsStr {
             target: "1 cBTC",
             cost_of_change: "1 cBTC",
-            fee_rate: "10",
-            lt_fee_rate: "10",
+            fee_rate: "10 sat/kwu",
+            lt_fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["1.5 cBTC", "1 sat"],
         };
 
@@ -551,8 +549,8 @@ mod tests {
         let params = ParamsStr {
             target: "6 sats",
             cost_of_change: "0",
-            fee_rate: "10",
-            lt_fee_rate: "20",
+            fee_rate: "10 sat/kwu",
+            lt_fee_rate: "20 sat/kwu",
             weighted_utxos: vec!["3 sats", "4 sats", "5 sats", "6 sats"], // eff_values: [1, 2, 3, 4]
         };
 
@@ -564,8 +562,8 @@ mod tests {
         let params = ParamsStr {
             target: "6 sats",
             cost_of_change: "0",
-            fee_rate: "20",
-            lt_fee_rate: "10",
+            fee_rate: "20 sat/kwu",
+            lt_fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["5 sats", "6 sats", "7 sats", "8 sats"], // eff_values: [1, 2, 3, 4]
         };
 
@@ -577,8 +575,8 @@ mod tests {
         let params = ParamsStr {
             target: "6 sats",
             cost_of_change: "1 sats",
-            fee_rate: "20",
-            lt_fee_rate: "10",
+            fee_rate: "20 sat/kwu",
+            lt_fee_rate: "10 sat/kwu",
             weighted_utxos: vec!["5 sats", "6 sats", "7 sats", "9 sats"], // eff_values: [1, 2, 3, 4]
         };
 
@@ -616,7 +614,7 @@ mod tests {
         let params = ParamsStr {
             target: "1 sats",
             cost_of_change: "18141417255681066410 sats",
-            fee_rate: "1",
+            fee_rate: "1 sat/kwu",
             lt_fee_rate: "0",
             weighted_utxos: vec!["8740670712339394302 sats"],
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,28 @@ mod tests {
         assert_eq!(inputs, expected_ref);
     }
 
+    // TODO check about adding this to rust-bitcoins from_str for FeeRate
+    pub(crate) fn parse_fee_rate(f: &str) -> FeeRate {
+        let rate_parts: Vec<_> = f.split(" ").collect();
+        let rate = rate_parts[0].parse::<u64>().unwrap();
+
+        match rate_parts.len() {
+            1 => {
+                assert!(rate == 0, "Try adding sat/kwu or sat/vb to fee_rate");
+                FeeRate::ZERO
+            }
+
+            2 => match rate_parts[1] {
+                "sat/kwu" => FeeRate::from_sat_per_kwu(rate),
+                "sat/vb" => FeeRate::from_sat_per_vb(rate).unwrap(),
+                "0" => FeeRate::ZERO,
+                _ => panic!("only support sat/kwu or sat/vb rates"),
+            },
+
+            _ => panic!("number, space then rate not parsed.  example: 10 sat/kwu"),
+        }
+    }
+
     #[derive(Debug, Clone, PartialEq, Ord, Eq, PartialOrd, Arbitrary)]
     pub struct Utxo {
         pub output: TxOut,


### PR DESCRIPTION
Currently all tests are sat/kwu implicitly.  However, some tests that are copied from core use sat/vB and it would be nice to just copy the tests without doing a math conversion.  Add the ability to annotate the fee_rate as either sat/kwu or sat/vb.