### PR TITLE
test: Add ability to choose and assert by effective_value

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -425,7 +425,9 @@ mod tests {
     }
 
     #[test]
-    fn select_coins_bnb_four() { assert_coin_select("4 cBTC", 8, &["3 cBTC/68 vb", "1 cBTC/68 vb"]); }
+    fn select_coins_bnb_four() {
+        assert_coin_select("4 cBTC", 8, &["3 cBTC/68 vb", "1 cBTC/68 vb"]);
+    }
 
     #[test]
     fn select_coins_bnb_five() {

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -355,7 +355,7 @@ mod tests {
             let fee_rate = parse_fee_rate(self.fee_rate);
             let lt_fee_rate = parse_fee_rate(self.lt_fee_rate);
 
-            let pool: UtxoPool = UtxoPool::new(self.weighted_utxos);
+            let pool: UtxoPool = UtxoPool::new(self.weighted_utxos, fee_rate);
 
             let result =
                 select_coins_bnb(target, cost_of_change, fee_rate, lt_fee_rate, &pool.utxos);
@@ -363,7 +363,7 @@ mod tests {
             if let Some((iterations, inputs)) = result {
                 assert_eq!(iterations, self.expected_iterations);
 
-                let expected: UtxoPool = UtxoPool::new(self.expected_utxos.unwrap());
+                let expected: UtxoPool = UtxoPool::new(self.expected_utxos.unwrap(), fee_rate);
                 assert_ref_eq(inputs, expected.utxos);
             } else {
                 assert!(self.expected_utxos.is_none());
@@ -575,8 +575,13 @@ mod tests {
             cost_of_change: "0",
             fee_rate: "10 sat/kwu",
             lt_fee_rate: "20 sat/kwu",
-            weighted_utxos: &["3 sats/0 wu", "4 sats/0 wu", "5 sats/0 wu", "6 sats/0 wu"],
-            expected_utxos: Some(&["5 sats/0 wu", "4 sats/0 wu", "3 sats/0 wu"]),
+            weighted_utxos: &[
+                "e(1 sats)/68 vb",
+                "e(2 sats)/68 vb",
+                "e(3 sats)/68 vb",
+                "e(4 sats)/68 vb",
+            ],
+            expected_utxos: Some(&["e(3 sats)/68 vb", "e(2 sats)/68 vb", "e(1 sats)/68 vb"]),
             expected_iterations: 12,
         }
         .assert();
@@ -589,8 +594,13 @@ mod tests {
             cost_of_change: "0",
             fee_rate: "20 sat/kwu",
             lt_fee_rate: "10 sat/kwu",
-            weighted_utxos: &["5 sats/0 wu", "6 sats/0 wu", "7 sats/0 wu", "8 sats/0 wu"],
-            expected_utxos: Some(&["8 sats/0 wu", "6 sats/0 wu"]),
+            weighted_utxos: &[
+                "e(1 sats)/68 vb",
+                "e(2 sats)/68 vb",
+                "e(3 sats)/68 vb",
+                "e(4 sats)/68 vb",
+            ],
+            expected_utxos: Some(&["e(4 sats)/68 vb", "e(2 sats)/68 vb"]),
             expected_iterations: 12,
         }
         .assert();
@@ -603,9 +613,14 @@ mod tests {
             cost_of_change: "1 sats",
             fee_rate: "20 sat/kwu",
             lt_fee_rate: "10 sat/kwu",
-            weighted_utxos: &["5 sats/0 wu", "6 sats/0 wu", "7 sats/0 wu", "9 sats/0 wu"],
-            expected_utxos: Some(&["9 sats/0 wu", "5 sats/0 wu"]),
-            expected_iterations: 14,
+            weighted_utxos: &[
+                "e(1 sats)/68 vb",
+                "e(2 sats)/68 vb",
+                "e(3 sats)/68 vb",
+                "e(4 sats)/68 vb",
+            ],
+            expected_utxos: Some(&["e(4 sats)/68 vb", "e(2 sats)/68 vb"]),
+            expected_iterations: 12,
         }
         .assert();
     }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -118,6 +118,17 @@ mod tests {
         }
     }
 
+    fn assert_coin_select(target_str: &str, expected_iterations: u32, expected_utxos: &[&str]) {
+        TestSRD {
+            target: target_str,
+            fee_rate: "10 sat/kwu",
+            weighted_utxos: &["1 cBTC/204 wu", "2 cBTC/204 wu"],
+            expected_utxos: Some(expected_utxos),
+            expected_iterations,
+        }
+        .assert();
+    }
+
     fn get_rng() -> StepRng {
         // [1, 2]
         // let mut vec: Vec<u32> = (1..3).collect();
@@ -130,17 +141,6 @@ mod tests {
         // is used as the rng.  The first is removed from the beginning and added to
         // the end while the remaining elements keep their order.
         StepRng::new(0, 0)
-    }
-
-    fn assert_coin_select(target_str: &str, expected_iterations: u32, expected_utxos: &[&str]) {
-        TestSRD {
-            target: target_str,
-            fee_rate: "10 sat/kwu",
-            weighted_utxos: &["1 cBTC/204 wu", "2 cBTC/204 wu"],
-            expected_utxos: Some(expected_utxos),
-            expected_iterations,
-        }
-        .assert();
     }
 
     #[test]

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -99,16 +99,19 @@ mod tests {
 
     impl TestSRD<'_> {
         fn assert(&self) {
-            let fee_rate = parse_fee_rate(self.fee_rate);
             let target = Amount::from_str(self.target).unwrap();
+            let fee_rate = parse_fee_rate(self.fee_rate);
 
-            let pool: UtxoPool = UtxoPool::new(self.weighted_utxos);
+            let pool: UtxoPool = UtxoPool::new(self.weighted_utxos, fee_rate);
+
             let result = select_coins_srd(target, fee_rate, &pool.utxos, &mut get_rng());
 
             if let Some((iterations, inputs)) = result {
                 assert_eq!(iterations, self.expected_iterations);
 
-                let expected: UtxoPool = UtxoPool::new(self.expected_utxos.unwrap());
+                let expected_selection = self.expected_utxos.unwrap();
+                let expected: UtxoPool = UtxoPool::new(expected_selection, fee_rate);
+
                 assert_ref_eq(inputs, expected.utxos);
             } else {
                 assert!(self.expected_utxos.is_none());
@@ -191,7 +194,7 @@ mod tests {
         TestSRD {
             target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
             fee_rate: "10 sat/kwu",
-            weighted_utxos: &["1 cBTC/68 vb", "2 cBTC/68 vb", "1 sat/68 vb"], // 1 sat @ 204 has negative effective_value
+            weighted_utxos: &["1 cBTC/68 vb", "2 cBTC/68 vb", "e(-1 sat)/68 vb"],
             expected_utxos: Some(&["2 cBTC/68 vb", "1 cBTC/68 vb"]),
             expected_iterations: 3,
         }
@@ -217,7 +220,7 @@ mod tests {
         TestSRD {
             target: "3 cBTC",
             fee_rate: "10 sat/kwu",
-            weighted_utxos: &["1 cBTC/68 vb", "2 cBTC/68 vb"],
+            weighted_utxos: &["e(1 cBTC)/68 vb", "e(2 cBTC)/68 vb"],
             expected_utxos: None,
             expected_iterations: 0,
         }


### PR DESCRIPTION
A set of UTXOs for testing can be defined by either effective_value using `e()` or absolute value as default.

For example:
```rust
weighted_utxos: &["1 sat/68vb", "e(1 sat)/68 vb", "e(1 sat)/204 wu"]
```

This will evaluate to two `UTXOs` with equivalent effective_values of 1 sat even though they have different sizes (`68 vb` and `204 wu`).  Also, there will be a `UTXO` with negative effective value since the absolute value is given as `1 sat/68 vb` given some positive `fee_rate`.

Then, assert the smallest UTXO with a positive effective_value is returned:

```rust
expected_utxos: &["e(1 sat)/204 wu"]
```

Motivation:
During the selection process, input values are converted to effective_values, and then the search begins using the calculated effective_values.  In the test-suit, it's often the case that it's desired to test what happens given a particular effective_value.
Instead of manually figuring out what absolute_value is needed to result in the search routines effective_value, add the ability to denote by effective_value `e()`.  This is done by wrapping the value with e() otherwise it's assumed to be an absolute value.

Motivated by: https://github.com/bitcoin/bitcoin/pull/29532

Unlike bitcoin core's 29532 however, this PR allows for either absolute or effective_values to be defined instead of using all effective_values.  That's because there are tests that depend on the `absolute_value`, such as how the code behaves when an absolute value of `Amount::MAX` is passed.