### PR TITLE
Switch to weight

### DIFF
--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -5,12 +5,11 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[derive(Debug, Clone)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight,
+    weight: Weight,
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight { self.satisfaction_weight }
-
+    fn weight(&self) -> Weight { self.weight }
     fn value(&self) -> Amount { self.output.value }
 }
 
@@ -20,12 +19,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let one = Utxo {
         output: TxOut { value: Amount::from_sat(1_000), script_pubkey: ScriptBuf::new() },
-        satisfaction_weight: Weight::ZERO,
+        weight: Weight::ZERO,
     };
 
     let two = Utxo {
         output: TxOut { value: Amount::from_sat(3), script_pubkey: ScriptBuf::new() },
-        satisfaction_weight: Weight::ZERO,
+        weight: Weight::ZERO,
     };
 
     let target = Amount::from_sat(1_003);

--- a/fuzz/fuzz_targets/select_coins.rs
+++ b/fuzz/fuzz_targets/select_coins.rs
@@ -8,12 +8,12 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight,
+    weight: Weight,
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/fuzz/fuzz_targets/select_coins_bnb.rs
+++ b/fuzz/fuzz_targets/select_coins_bnb.rs
@@ -8,12 +8,12 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight
+    weight: Weight
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/fuzz/fuzz_targets/select_coins_srd.rs
+++ b/fuzz/fuzz_targets/select_coins_srd.rs
@@ -9,12 +9,12 @@ use rand::thread_rng;
 #[derive(Arbitrary, Debug)]
 pub struct Utxo {
     output: TxOut,
-    satisfaction_weight: Weight
+    weight: Weight
 }
 
 impl WeightedUtxo for Utxo {
-    fn satisfaction_weight(&self) -> Weight {
-        self.satisfaction_weight
+    fn weight(&self) -> Weight {
+        self.weight
     }
 
     fn value(&self) -> Amount {

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -329,12 +329,11 @@ mod tests {
 
     use arbitrary::{Arbitrary, Unstructured};
     use arbtest::arbtest;
-    use bitcoin::transaction::effective_value;
     use bitcoin::{Amount, Weight};
 
     use super::*;
     use crate::tests::{assert_proptest_bnb, assert_ref_eq, parse_fee_rate, Utxo, UtxoPool};
-    use crate::WeightedUtxo;
+    use crate::{effective_value, WeightedUtxo};
 
     const TX_IN_BASE_WEIGHT: u64 = 160;
 

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -912,7 +912,8 @@ mod tests {
                     let result = select_coins_bnb(target, Amount::ZERO, fee_rate, fee_rate, &utxos);
 
                     if let Some((_i, utxos)) = result {
-                        let sum: SignedAmount = utxos.clone()
+                        let sum: SignedAmount = utxos
+                            .clone()
                             .into_iter()
                             .map(|u| {
                                 effective_value(fee_rate, u.satisfaction_weight(), u.value())
@@ -1002,11 +1003,14 @@ mod tests {
                         assert_eq!(effective_value_sum, target);
 
                         // TODO checked_add not available in Weight
-                        let result_sum =
-                            utxos.iter().try_fold(Weight::ZERO, |acc, item| acc.checked_add(item.satisfaction_weight()));
+                        let result_sum = utxos.iter().try_fold(Weight::ZERO, |acc, item| {
+                            acc.checked_add(item.satisfaction_weight())
+                        });
 
                         let target_sum =
-                            target_selection.iter().try_fold(Weight::ZERO, |acc, item| acc.checked_add(item.satisfaction_weight()));
+                            target_selection.iter().try_fold(Weight::ZERO, |acc, item| {
+                                acc.checked_add(item.satisfaction_weight())
+                            });
 
                         if let Some(s) = target_sum {
                             assert!(result_sum.unwrap() <= s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,20 +61,13 @@ pub trait WeightedUtxo {
         effective_value(fee_rate, self.weight(), self.value())
     }
 
-    /// Computes the fee to spend this `Utxo`.
-    ///
-    /// The fee is calculated as: fee rate * (satisfaction_weight + the base weight).
-    fn calculate_fee(&self, fee_rate: FeeRate) -> Option<Amount> {
-        fee_rate.checked_mul_by_weight(self.weight())
-    }
-
     /// Computes how wastefull it is to spend this `Utxo`
     ///
     /// The waste is the difference of the fee to spend this `Utxo` now compared with the expected
     /// fee to spend in the future (long_term_fee_rate).
     fn waste(&self, fee_rate: FeeRate, long_term_fee_rate: FeeRate) -> Option<SignedAmount> {
-        let fee: SignedAmount = self.calculate_fee(fee_rate)?.to_signed().ok()?;
-        let lt_fee: SignedAmount = self.calculate_fee(long_term_fee_rate)?.to_signed().ok()?;
+        let fee: SignedAmount = fee_rate.fee_wu(self.weight())?.to_signed().ok()?;
+        let lt_fee: SignedAmount = long_term_fee_rate.fee_wu(self.weight())?.to_signed().ok()?;
         fee.checked_sub(lt_fee)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,28 @@ const OUT_POINT_SIZE: u64 = 32 + 4;
 // https://github.com/rust-bitcoin/rust-bitcoin/blob/35202ba51bef3236e6ed1007a0d2111265b6498c/bitcoin/src/blockdata/transaction.rs#L249
 const BASE_WEIGHT: Weight = Weight::from_vb_unwrap(OUT_POINT_SIZE + SEQUENCE_SIZE);
 
+/// Computes the value of an output accounting for the cost to spend it.
+///
+/// The effective_value can be calculated as: value - (fee_rate * weight).
+///
+/// Note: the effective value of a `Transaction` may increase less than the effective value of
+/// a `TxOut` when adding another `TxOut` to the transaction. This happens when the new
+/// `TxOut` added causes the output length `VarInt` to increase its encoding length.
+///
+/// # Parameters
+///
+/// * `fee_rate` - the fee rate of the transaction being created.
+/// * `satisfaction_weight` - satisfied spending conditions weight.
+pub(crate) fn effective_value(
+    fee_rate: FeeRate,
+    satisfaction_weight: Weight,
+    value: Amount,
+) -> Option<SignedAmount> {
+    let weight = satisfaction_weight.checked_add(BASE_WEIGHT)?;
+    let signed_input_fee = fee_rate.fee_wu(weight)?.to_signed().ok()?;
+    value.to_signed().ok()?.checked_sub(signed_input_fee)
+}
+
 /// Behavior needed for coin-selection.
 pub trait WeightedUtxo {
     /// The weight of the witness data and `scriptSig` which is used to then calculate the fee on
@@ -46,20 +68,11 @@ pub trait WeightedUtxo {
     /// The UTXO value.
     fn value(&self) -> Amount;
 
-    /// Computes the value of an output accounting for the cost of spending it.
+    /// Computes the effective_value.
     ///
-    /// The effective value is the value of an output value minus the amount to spend it.  That is, the
-    /// effective_value can be calculated as: value - (fee_rate * weight).
-    ///
-    /// Note: the effective value of a Transaction may increase less than the effective value of
-    /// a `TxOut` (UTXO) when adding another `TxOut` to the transaction.  This happens when the new
-    /// `TxOut` added causes the output length `VarInt` to increase its encoding length.
-    ///
-    /// see also:
-    /// <https://github.com/rust-bitcoin/rust-bitcoin/blob/59c806996ce18e88394eb4e2c265986c8d3a6620/bitcoin/src/blockdata/transaction.rs>
+    /// The effective value is calculated as: fee rate * (satisfaction_weight + the base weight).
     fn effective_value(&self, fee_rate: FeeRate) -> Option<SignedAmount> {
-        let signed_input_fee = self.calculate_fee(fee_rate)?.to_signed().ok()?;
-        self.value().to_signed().ok()?.checked_sub(signed_input_fee)
+        effective_value(fee_rate, self.satisfaction_weight(), self.value())
     }
 
     /// Computes the fee to spend this `Utxo`.

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -188,6 +188,9 @@ mod tests {
 
     #[test]
     fn select_coins_skip_negative_effective_value() {
+        // A value of 2 cBTC is needed after CHANGE_LOWER is subtracted.
+        // After randomization, the effective values are: [1,9 cBTC, -2 sats, 0.1 cBTC]
+        // The middle utxo is skipped since it's effective value is negative.
         TestSRD {
             target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
             fee_rate: "10 sat/kwu",
@@ -200,6 +203,8 @@ mod tests {
 
     #[test]
     fn select_coins_srd_fee_rate_error() {
+        // Setting very high FeeRate of u64::MAX causes the effective_value to overflow
+        // returning None.
         TestSRD {
             target: "1 cBTC",
             fee_rate: "18446744073709551615 sat/kwu",

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -4,11 +4,10 @@
 //!
 //! This module introduces the Single Random Draw Coin-Selection Algorithm.
 
-use bitcoin::blockdata::transaction::effective_value;
 use bitcoin::{Amount, FeeRate};
 use rand::seq::SliceRandom;
 
-use crate::{Return, WeightedUtxo, CHANGE_LOWER};
+use crate::{effective_value, Return, WeightedUtxo, CHANGE_LOWER};
 
 /// Randomize the input set and select coins until the target is reached.
 ///

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -7,7 +7,7 @@
 use bitcoin::{Amount, FeeRate};
 use rand::seq::SliceRandom;
 
-use crate::{effective_value, Return, WeightedUtxo, CHANGE_LOWER};
+use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 
 /// Randomize the input set and select coins until the target is reached.
 ///
@@ -54,9 +54,7 @@ pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
     let mut iteration = 0;
     for w_utxo in origin {
         iteration += 1;
-        let utxo_value = w_utxo.value();
-        let utxo_weight = w_utxo.satisfaction_weight();
-        let effective_value = effective_value(fee_rate, utxo_weight, utxo_value);
+        let effective_value = w_utxo.effective_value(fee_rate);
 
         if let Some(e) = effective_value {
             if let Ok(v) = e.to_unsigned() {


### PR DESCRIPTION
Core uses just weight in coin-grinder, and it's complicated to maintain both satisfaction_weight and weight.  Therefore, switch to just weight units for all algorithms.