### PR TITLE
Remove unchecked ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ A basic performance comparison between this Rust BnB implementation and [Bitcoin
 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
-|      Rust BnB|    1,000|598,370|
+|      Rust BnB|    1,000|548,380|
 |  C++ Core BnB|    1,000|816,374|
 
-Note: The measurements where recorded using rustc 1.75.  Expect worse performance with MSRV.
+Note: The measurements where recorded using rustc 1.87.  Expect worse performance with MSRV.
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
rust-bitcoin deprecated unchecked ops in commit: https://github.com/rust-bitcoin/rust-bitcoin/pull/3759/commits/b895c9aad4e56ff7cf5420f71ae501f942a81326

Updated benchmark performance using the latest stable compiler and switching to native u64/i64 instead of using unchecked ops results in a nominal performance increase.