### PR TITLE
test: Add check for valid waste

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -1029,7 +1029,7 @@ mod tests {
 
             let result = select_coins_bnb(target, cost_of_change, fee_rate, lt_fee_rate, &utxos);
 
-            assert_proptest_bnb(target, cost_of_change, fee_rate, pool, result);
+            assert_proptest_bnb(target, cost_of_change, fee_rate, lt_fee_rate, pool, result);
 
             Ok(())
         });


### PR DESCRIPTION
When computing how wasteful a UTXO is, it's possible the waste calculation may return None, making it not possible to consider this UTXO as a candidate for selection.  If there are zero UTXOs that have a waste calculation that is Some, then there are no possible solutions from that pool.