### PR TITLE
test: Remove unused struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,9 +180,6 @@ mod tests {
         pub weight: Weight,
     }
 
-    #[derive(Debug, PartialEq, Eq)]
-    pub struct ParseUtxoError;
-
     impl<'a> Arbitrary<'a> for UtxoPool {
         fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
             let len = u.arbitrary_len::<u64>()? % MAX_POOL_SIZE;


### PR DESCRIPTION
This was added with a Utxo from string implementation which was subsequently removed.