### PR TITLE
Update fee_rate parser terminology

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod tests {
 
             2 => match rate_parts[1] {
                 "sat/kwu" => FeeRate::from_sat_per_kwu(rate),
-                "sat/vb" => FeeRate::from_sat_per_vb(rate).unwrap(),
+                "sat/vB" => FeeRate::from_sat_per_vb(rate).unwrap(),
                 "0" => FeeRate::ZERO,
                 _ => panic!("only support sat/kwu or sat/vB rates"),
             },


### PR DESCRIPTION
b is for bits while B is for Bytes.  Therefore, it is sats per virtual Bytes, not virtual bits.