### PR TITLE
draft: Add Error return type

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -9,6 +9,10 @@ use bitcoin::{Amount, FeeRate};
 
 use crate::{Return, WeightedUtxo};
 
+// Total_Tries in Core:
+// https://github.com/bitcoin/bitcoin/blob/1d9da8da309d1dbf9aef15eb8dc43b4a2dc3d309/src/wallet/coinselection.cpp#L74
+pub const ITERATION_LIMIT: u32 = 100_000;
+
 /// Performs a deterministic depth first branch and bound search for a changeless solution.
 ///
 /// A changeless solution is one that exceeds the target amount and is less than target amount plus
@@ -153,10 +157,6 @@ pub fn select_coins_bnb<Utxo: WeightedUtxo>(
     long_term_fee_rate: FeeRate,
     weighted_utxos: &[Utxo],
 ) -> Return<Utxo> {
-    // Total_Tries in Core:
-    // https://github.com/bitcoin/bitcoin/blob/1d9da8da309d1dbf9aef15eb8dc43b4a2dc3d309/src/wallet/coinselection.cpp#L74
-    const ITERATION_LIMIT: u32 = 100_000;
-
     let mut iteration = 0;
     let mut index = 0;
     let mut backtrack;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,28 @@
+/// Error types.
+use std::error::Error as E;
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
+pub enum OverflowError {
+    Addition,
+    Multiplication,
+    Subtraction,
+}
+
+impl E for OverflowError {}
+
+impl fmt::Display for OverflowError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OverflowError::Addition => {
+                write!(f, "Arithmetic overflow during addition")
+            }
+            OverflowError::Multiplication => {
+                write!(f, "Arithmetic overflow during multiplication")
+            }
+            OverflowError::Subtraction => {
+                write!(f, "Arithmetic overflow during subtraction")
+            }
+        }
+    }
+}

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -19,19 +19,9 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 /// * `weighted_utxos` - Weighted UTXOs from which to sum the target amount.
 /// * `rng` - used primarily by tests to make the selection deterministic.
 ///
-/// # Returns
+/// # Errors
 ///
-/// * `Some((u32, Vec<WeightedUtxo>))` where `Vec<WeightedUtxo>` is empty on no matches found.
-///   An empty vec signifies that all possibilities where explored successfully and no match
-///   could be found with the given parameters.  The first element of the tuple is a u32 which
-///   represents the number of iterations needed to find a solution.
-/// * `None` un-expected results OR no match found.  A future implementation may add Error types
-///   which will differentiate between an unexpected error and no match found.  Currently, a None
-///   type occurs when one or more of the following criteria are met:
-///     - Overflow when summing available UTXOs
-///     - Not enough potential amount to meet the target
-///     - Target Amount is zero (no match possible)
-///     - Search was successful yet no match found
+/// * Unrecoverable Arithmetic Overflow
 pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
     target: Amount,
     fee_rate: FeeRate,
@@ -39,7 +29,7 @@ pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
     rng: &mut R,
 ) -> Return<'a, Utxo> {
     if target > Amount::MAX_MONEY {
-        return None;
+        return Ok((0, vec![]));
     }
 
     let mut result: Vec<_> = weighted_utxos.iter().collect();
@@ -63,13 +53,13 @@ pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
                 result.push(w_utxo);
 
                 if value >= threshold {
-                    return Some((iteration, result));
+                    return Ok((iteration, result));
                 }
             }
         }
     }
 
-    None
+    Ok((iteration, vec![]))
 }
 
 #[cfg(test)]
@@ -90,7 +80,7 @@ mod tests {
         target: &'a str,
         fee_rate: &'a str,
         weighted_utxos: &'a [&'a str],
-        expected_utxos: Option<&'a [&'a str]>,
+        expected_utxos: &'a [&'a str],
         expected_iterations: u32,
     }
 
@@ -103,15 +93,15 @@ mod tests {
 
             let result = select_coins_srd(target, fee_rate, &pool.utxos, &mut get_rng());
 
-            if let Some((iterations, inputs)) = result {
+            if let Ok((iterations, inputs)) = result {
                 assert_eq!(iterations, self.expected_iterations);
 
-                let expected_selection = self.expected_utxos.unwrap();
-                let expected: UtxoPool = UtxoPool::new(expected_selection, fee_rate);
+                //let expected_selection = self.expected_utxos.unwrap();
+                let expected: UtxoPool = UtxoPool::new(self.expected_utxos, fee_rate);
 
                 assert_ref_eq(inputs, expected.utxos);
             } else {
-                assert!(self.expected_utxos.is_none());
+                assert!(self.expected_utxos.is_empty());
                 // Remove this check once iteration count is returned by error
                 assert_eq!(self.expected_iterations, 0);
             }
@@ -123,7 +113,7 @@ mod tests {
             target: target_str,
             fee_rate: "10 sat/kwu",
             weighted_utxos: &["1 cBTC/204 wu", "2 cBTC/204 wu"],
-            expected_utxos: Some(expected_utxos),
+            expected_utxos,
             expected_iterations,
         }
         .assert();
@@ -168,7 +158,7 @@ mod tests {
             target: "11 cBTC",
             fee_rate: "0",
             weighted_utxos: &["1.5 cBTC"],
-            expected_utxos: Some(&["1.5 cBTC"]),
+            expected_utxos: &["1.5 cBTC"],
             expected_iterations: 2,
         }
         .assert();
@@ -180,8 +170,8 @@ mod tests {
             target: "4 cBTC",
             fee_rate: "0",
             weighted_utxos: &["1 cBTC/68 vB", "2 cBTC/68 vB"],
-            expected_utxos: None,
-            expected_iterations: 0,
+            expected_utxos: &[],
+            expected_iterations: 2,
         }
         .assert();
     }
@@ -195,7 +185,7 @@ mod tests {
             target: "1.95 cBTC", // 2 cBTC - CHANGE_LOWER
             fee_rate: "10 sat/kwu",
             weighted_utxos: &["1 cBTC/68 vB", "2 cBTC/68 vB", "e(-1 sat)/68 vB"],
-            expected_utxos: Some(&["2 cBTC/68 vB", "1 cBTC/68 vB"]),
+            expected_utxos: &["2 cBTC/68 vB", "1 cBTC/68 vB"],
             expected_iterations: 3,
         }
         .assert();
@@ -209,8 +199,8 @@ mod tests {
             target: "3 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: &["e(1 cBTC)/68 vB", "e(2 cBTC)/68 vB"],
-            expected_utxos: None,
-            expected_iterations: 0,
+            expected_utxos: &[],
+            expected_iterations: 2,
         }
         .assert();
     }
@@ -226,7 +216,7 @@ mod tests {
             target: "2 cBTC",
             fee_rate: "10 sat/kwu",
             weighted_utxos: &["1 cBTC/68 vB", "2050000 sats/68 vB"],
-            expected_utxos: Some(&["2050000 sats/68 vB", "1 cBTC/68 vB"]),
+            expected_utxos: &["2050000 sats/68 vB", "1 cBTC/68 vB"],
             expected_iterations: 2,
         }
         .assert();
@@ -238,7 +228,7 @@ mod tests {
             target: "18446744073709551615 sat", // u64::MAX
             fee_rate: "10 sat/kwu",
             weighted_utxos: &["1 cBTC/68 vB"],
-            expected_utxos: None,
+            expected_utxos: &[],
             expected_iterations: 0,
         }
         .assert();
@@ -254,7 +244,7 @@ mod tests {
                 "1 cBTC/68 vB",
                 "9223372036854775808 sat/68 vB", //i64::MAX + 1
             ],
-            expected_utxos: Some(&["1 cBTC/68 vB"]),
+            expected_utxos: &["1 cBTC/68 vB"],
             expected_iterations: 2,
         }
         .assert();
@@ -268,7 +258,7 @@ mod tests {
             let fee_rate = FeeRate::arbitrary(u)?;
 
             let utxos = pool.utxos.clone();
-            let result: Option<_> = select_coins_srd(target, fee_rate, &utxos, &mut get_rng());
+            let result: Result<_, _> = select_coins_srd(target, fee_rate, &utxos, &mut get_rng());
 
             assert_proptest_srd(target, fee_rate, pool, result);
 


### PR DESCRIPTION
Differentiate an unrecoverable arithmetic overflow from other types of results.  For example, hitting the iteration limit or other inputs where no solution or a non-optimal solution is returned is different from parameters where a search is unable to proceed.

In order to make clear the results returned, add an error module with the following possible overflow:

* AdditionOverflow
* MultiplicationOverflow
* SubtractOverflow