### PR TITLE
test: refactor arb tests

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -902,11 +902,7 @@ mod tests {
                     assert!(utxo_sum >= target);
                     assert!(utxo_sum <= (target + cost_of_change).unwrap());
                 } else {
-                    let available_value = pool
-                        .utxos
-                        .iter()
-                        .map(|u| u.effective_value(fee_rate_a).unwrap_or(crate::SignedAmount::ZERO))
-                        .checked_sum();
+                    let available_value = pool.available_value(fee_rate_a);
                     assert!(
                         available_value.is_none()
                             || target == Amount::ZERO

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -888,19 +888,12 @@ mod tests {
                     }
 
                     assert!(i > 0);
-                    let utxo_sum: Amount = utxos_a
-                        .into_iter()
-                        .map(|u| {
-                            crate::effective_value(fee_rate_a, u.weight(), u.value())
-                                .unwrap()
-                                .to_unsigned()
-                                .unwrap()
-                        })
-                        .checked_sum()
-                        .unwrap();
-
-                    assert!(utxo_sum >= target);
-                    assert!(utxo_sum <= (target + cost_of_change).unwrap());
+                    crate::tests::assert_target_selection(
+                        &utxos_a,
+                        fee_rate_a,
+                        target,
+                        upper_bound,
+                    );
                 } else {
                     let available_value = pool.available_value(fee_rate_a);
                     assert!(

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -151,7 +151,7 @@ pub fn select_coins_bnb<Utxo: WeightedUtxo>(
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
     weighted_utxos: &[Utxo],
-) -> Return<Utxo> {
+) -> Return<'_, Utxo> {
     // Total_Tries in Core:
     // https://github.com/bitcoin/bitcoin/blob/1d9da8da309d1dbf9aef15eb8dc43b4a2dc3d309/src/wallet/coinselection.cpp#L74
     const ITERATION_LIMIT: u32 = 100_000;
@@ -304,7 +304,7 @@ fn index_to_utxo_list<Utxo: WeightedUtxo>(
     iterations: u32,
     index_list: Vec<usize>,
     wu: Vec<(u64, i64, &Utxo)>,
-) -> Return<Utxo> {
+) -> Return<'_, Utxo> {
     let mut result: Vec<_> = Vec::new();
     let list = index_list;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,17 @@ mod tests {
 
             UtxoPool { utxos }
         }
+
+        fn effective_value_sum(utxos: &[Utxo], fee_rate: FeeRate) -> Option<SignedAmount> {
+            utxos
+                .iter()
+                .map(|u| u.effective_value(fee_rate).unwrap_or(SignedAmount::ZERO))
+                .checked_sum()
+        }
+
+        pub fn available_value(&self, fee_rate: FeeRate) -> Option<SignedAmount> {
+            Self::effective_value_sum(&self.utxos, fee_rate)
+        }
     }
 
     impl WeightedUtxo for Utxo {
@@ -342,11 +353,7 @@ mod tests {
 
                 assert!(utxo_sum >= target);
             } else {
-                let available_value = pool
-                    .utxos
-                    .iter()
-                    .map(|u| u.effective_value(fee_rate).unwrap_or(crate::SignedAmount::ZERO))
-                    .checked_sum();
+                let available_value = pool.available_value(fee_rate);
                 assert!(available_value.is_none() || available_value.unwrap() < target.to_signed());
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,32 +371,6 @@ mod tests {
         }
     }
 
-    pub fn assert_proptest_srd(
-        target: Amount,
-        fee_rate: FeeRate,
-        pool: UtxoPool,
-        result: Return<Utxo>,
-    ) {
-        let mut srd_solutions: Vec<Vec<&Utxo>> = Vec::new();
-        build_possible_solutions_srd(&pool, fee_rate, target, &mut srd_solutions);
-
-        if let Some((_i, utxos)) = result {
-            let utxo_sum: Amount = utxos
-                .into_iter()
-                .map(|u| {
-                    effective_value(fee_rate, u.weight(), u.value()).unwrap().to_unsigned().unwrap()
-                })
-                .checked_sum()
-                .unwrap();
-
-            assert!(utxo_sum >= target);
-        } else {
-            assert!(
-                target > Amount::MAX_MONEY || target == Amount::ZERO || srd_solutions.is_empty()
-            );
-        }
-    }
-
     pub fn assert_proptest(
         target: Amount,
         cost_of_change: Amount,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
     fee_rate: FeeRate,
     long_term_fee_rate: FeeRate,
     weighted_utxos: &[Utxo],
-) -> Return<Utxo> {
+) -> Return<'_, Utxo> {
     let bnb =
         select_coins_bnb(target, cost_of_change, fee_rate, long_term_fee_rate, weighted_utxos);
 

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -278,11 +278,7 @@ mod tests {
 
                 assert!(utxo_sum >= target);
             } else {
-                let available_value = pool
-                    .utxos
-                    .iter()
-                    .map(|u| u.effective_value(fee_rate).unwrap_or(crate::SignedAmount::ZERO))
-                    .checked_sum();
+                let available_value = pool.available_value(fee_rate);
                 assert!(available_value.is_none() || available_value.unwrap() < target.to_signed());
             }
 

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -243,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn select_coins_bnb_utxo_pool_sum_overflow() {
+    fn select_coins_srd_utxo_pool_sum_overflow() {
         TestSRD {
             target: "1 cBTC",
             fee_rate: "0",

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -265,18 +265,7 @@ mod tests {
 
             if let Some((i, utxos)) = result {
                 assert!(i > 0);
-                let utxo_sum: Amount = utxos
-                    .into_iter()
-                    .map(|u| {
-                        crate::effective_value(fee_rate, u.weight(), u.value())
-                            .unwrap()
-                            .to_unsigned()
-                            .unwrap()
-                    })
-                    .checked_sum()
-                    .unwrap();
-
-                assert!(utxo_sum >= target);
+                crate::tests::assert_target_selection(&utxos, fee_rate, target, None);
             } else {
                 let available_value = pool.available_value(fee_rate);
                 assert!(available_value.is_none() || available_value.unwrap() < target.to_signed());


### PR DESCRIPTION
Instead of building a random solution using brute force, just seed a solution into the initial pool.  This greatly improves test speed and reduces test complexity.