### PR TITLE
chore: bump criterion version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rand = { version = "0.8.5", default-features = false, optional = true }
 
 [dev-dependencies]
 bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "806b34aefc554c23cec2d1293113a589718c8cdf", features = ["arbitrary"] }
-criterion = "0.3"
+criterion = "0.6"
 bitcoin-coin-selection = {path = ".", features = ["rand"]}
 rand = "0.8.5"
 arbitrary = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A basic performance comparison between this Rust BnB implementation and [Bitcoin
 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
-|      Rust BnB|    1,000|591,730|
+|      Rust BnB|    1,000|499,600|
 |  C++ Core BnB|    1,000|816,374|
 
 Note: The measurements where recorded using rustc 1.90.  Expect worse performance with MSRV.

--- a/benches/coin_selection.rs
+++ b/benches/coin_selection.rs
@@ -1,6 +1,6 @@
 use bitcoin_coin_selection::{select_coins_bnb, WeightedUtxo};
 use bitcoin_units::{Amount, FeeRate, Weight};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 #[derive(Debug, Clone)]
 pub struct Utxo {
@@ -27,14 +27,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("bnb 1000", |b| {
         b.iter(|| {
-            let (iteration_count, inputs) = select_coins_bnb(
-                black_box(target),
-                black_box(cost_of_change),
-                black_box(FeeRate::ZERO),
-                black_box(FeeRate::ZERO),
-                black_box(&utxo_pool),
-            )
-            .unwrap();
+            let (iteration_count, inputs) =
+                select_coins_bnb(target, cost_of_change, FeeRate::ZERO, FeeRate::ZERO, &utxo_pool)
+                    .unwrap();
             assert_eq!(iteration_count, 100000);
 
             assert_eq!(2, inputs.len());


### PR DESCRIPTION
The real_blackbox feature no longer has any impact. Criterion always uses std::hint::black_box() now.