### PR TITLE
test: remove pool size limits from Arbitrary UtxoPool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn select_coins<Utxo: WeightedUtxo>(
 mod tests {
     use std::str::FromStr;
 
-    use arbitrary::{Arbitrary, Result, Unstructured};
+    use arbitrary::Arbitrary;
     use arbtest::arbtest;
     use bitcoin_units::{Amount, CheckedSum, Weight};
 
@@ -194,30 +194,30 @@ mod tests {
         pub weight: Weight,
     }
 
-    impl<'a> Arbitrary<'a> for UtxoPool {
-        fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-            let pool: Vec<Utxo> = Vec::arbitrary(u)?;
-            let valid: Vec<_> = pool
-                .clone()
-                .into_iter()
-                .scan(Amount::ZERO, |state, x| {
-                    let sum = *state + x.value();
-                    if sum.is_valid() {
-                        *state = sum.unwrap();
-                        Some(*state)
-                    } else {
-                        None
-                    }
-                })
-                .zip(pool)
-                .map(|(_, u)| u)
-                .collect();
+    //impl<'a> Arbitrary<'a> for UtxoPool {
+        //fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+            //let pool: Vec<Utxo> = Vec::arbitrary(u)?;
+            //let valid: Vec<_> = pool
+                //.clone()
+                //.into_iter()
+                //.scan(Amount::ZERO, |state, x| {
+                    //let sum = *state + x.value();
+                    //if sum.is_valid() {
+                        //*state = sum.unwrap();
+                        //Some(*state)
+                    //} else {
+                        //None
+                    //}
+                //})
+                //.zip(pool)
+                //.map(|(_, u)| u)
+                //.collect();
 
-            Ok(UtxoPool { utxos: valid })
-        }
-    }
+            //Ok(UtxoPool { utxos: valid })
+        //}
+    //}
 
-    #[derive(Debug)]
+    #[derive(Debug, Arbitrary)]
     pub struct UtxoPool {
         pub utxos: Vec<Utxo>,
     }


### PR DESCRIPTION
Since it is technically possible the algorithms could be passed a pool with amounts summing to more than 21 million `BTC`, the fuzz tests and prop-test ought reflect that.  However, ideally the algorithm's should take a `UtxoPool` struct as argument that makes such a thing as non-consensus arguments impossible.  This is planned for in the next version.