### PR TITLE
Use concrete type instead of generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ A basic performance comparison between implementations using commodity hardware 
 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
-|      Rust SRD|    1,000| 34,129|
-|      Rust BnB|    1,000|499,600|
+|      Rust SRD|    1,000| 36,363|
+|      Rust BnB|    1,000|543,700|
 |  C++ Core BnB|    1,000|816,374|
 
 Note: The measurements where recorded using rustc 1.90.  Expect worse performance with MSRV.

--- a/benches/bnb_selection.rs
+++ b/benches/bnb_selection.rs
@@ -2,24 +2,13 @@ use bitcoin_coin_selection::{select_coins_bnb, WeightedUtxo};
 use bitcoin_units::{Amount, FeeRate, Weight};
 use criterion::{criterion_group, criterion_main, Criterion};
 
-#[derive(Clone, Debug)]
-pub struct Utxo {
-    value: Amount,
-    weight: Weight,
-}
-
-impl WeightedUtxo for Utxo {
-    fn weight(&self) -> Weight { self.weight }
-    fn value(&self) -> Amount { self.value }
-}
-
 pub fn bnb_benchmark(c: &mut Criterion) {
     // https://github.com/bitcoin/bitcoin/blob/f3bc1a72825fe2b51f4bc20e004cef464f05b965/src/wallet/coinselection.h#L18
     let cost_of_change = Amount::from_sat_u32(50_000);
 
-    let one = Utxo { value: Amount::from_sat_u32(1_000), weight: Weight::ZERO };
+    let one = WeightedUtxo::new(Amount::from_sat_u32(1_000), Weight::ZERO);
 
-    let two = Utxo { value: Amount::from_sat_u32(3), weight: Weight::ZERO };
+    let two = WeightedUtxo::new(Amount::from_sat_u32(3), Weight::ZERO);
 
     let target = Amount::from_sat_u32(1_003);
     let mut utxo_pool = vec![one; 1000];

--- a/benches/srd_selection.rs
+++ b/benches/srd_selection.rs
@@ -3,19 +3,8 @@ use bitcoin_units::{Amount, FeeRate, Weight};
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::thread_rng;
 
-#[derive(Clone, Debug)]
-pub struct Utxo {
-    value: Amount,
-    weight: Weight,
-}
-
-impl WeightedUtxo for Utxo {
-    fn weight(&self) -> Weight { self.weight }
-    fn value(&self) -> Amount { self.value }
-}
-
 pub fn srd_benchmark(c: &mut Criterion) {
-    let utxo = Utxo { value: Amount::from_sat_u32(100), weight: Weight::ZERO };
+    let utxo = WeightedUtxo::new(Amount::from_sat_u32(100), Weight::ZERO);
     let pool = vec![utxo; 1_000];
 
     let target = Amount::from_sat_u32(50_000);

--- a/fuzz/fuzz_targets/select_coins.rs
+++ b/fuzz/fuzz_targets/select_coins.rs
@@ -1,23 +1,22 @@
 #![no_main]
 
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary, Unstructured, Result};
 use bitcoin_units::{FeeRate, Amount, Weight};
 use bitcoin_coin_selection::{select_coins, WeightedUtxo};
 use libfuzzer_sys::fuzz_target;
 
-#[derive(Arbitrary, Debug)]
-pub struct Utxo {
-    value: Amount,
-    weight: Weight,
+#[derive(Debug)]
+pub struct UtxoPool {
+    pub utxos: Vec<WeightedUtxo>,
 }
 
-impl WeightedUtxo for Utxo {
-    fn weight(&self) -> Weight {
-        self.weight
-    }
+impl<'a> Arbitrary<'a> for UtxoPool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let init: Vec<(Amount, Weight)> = Vec::arbitrary(u)?;
+        let pool: Vec<WeightedUtxo> =
+            init.iter().map(|i| WeightedUtxo::new(i.0, i.1)).collect();
 
-    fn value(&self) -> Amount {
-        self.value
+        Ok(UtxoPool { utxos: pool })
     }
 }
 
@@ -28,7 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let cost_of_change = Amount::arbitrary(&mut u).unwrap();
     let fee_rate = FeeRate::arbitrary(&mut u).unwrap();
     let lt_fee_rate = FeeRate::arbitrary(&mut u).unwrap();
-    let wu = Vec::<Utxo>::arbitrary(&mut u).unwrap();
+    let pool = UtxoPool::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins(target, cost_of_change, fee_rate, lt_fee_rate, &wu);
+    let _ = select_coins(target, cost_of_change, fee_rate, lt_fee_rate, &pool.utxos);
 });

--- a/fuzz/fuzz_targets/select_coins_bnb.rs
+++ b/fuzz/fuzz_targets/select_coins_bnb.rs
@@ -1,23 +1,22 @@
 #![no_main]
 
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::{Arbitrary, Unstructured, Result};
 use bitcoin_units::{FeeRate, Amount, Weight};
 use bitcoin_coin_selection::{select_coins_bnb, WeightedUtxo};
 use libfuzzer_sys::fuzz_target;
 
-#[derive(Arbitrary, Debug)]
-pub struct Utxo {
-    value: Amount,
-    weight: Weight
+#[derive(Debug)]
+pub struct UtxoPool {
+    pub utxos: Vec<WeightedUtxo>,
 }
 
-impl WeightedUtxo for Utxo {
-    fn weight(&self) -> Weight {
-        self.weight
-    }
+impl<'a> Arbitrary<'a> for UtxoPool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let init: Vec<(Amount, Weight)> = Vec::arbitrary(u)?;
+        let pool: Vec<WeightedUtxo> =
+            init.iter().map(|i| WeightedUtxo::new(i.0, i.1)).collect();
 
-    fn value(&self) -> Amount {
-        self.value
+        Ok(UtxoPool { utxos: pool })
     }
 }
 
@@ -28,7 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let cost_of_change = Amount::arbitrary(&mut u).unwrap();
     let fee_rate = FeeRate::arbitrary(&mut u).unwrap();
     let lt_fee_rate = FeeRate::arbitrary(&mut u).unwrap();
-    let wu = Vec::<Utxo>::arbitrary(&mut u).unwrap();
+    let pool = UtxoPool::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins_bnb(target, cost_of_change, fee_rate, lt_fee_rate, &wu);
+    let _ = select_coins_bnb(target, cost_of_change, fee_rate, lt_fee_rate, &pool.utxos);
 });

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -26,12 +26,12 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 /// If an arithmetic overflow occurs, the target can't be reached, or an un-expected error occurs.
 /// Note that if sufficient funds are supplied, and an overflow does not occur, then a solution
 /// should always be found.  Anything else would be an un-expected program error.
-pub fn select_coins_srd<'a, R: rand::Rng + ?Sized, Utxo: WeightedUtxo>(
+pub fn select_coins_srd<'a, R: rand::Rng + ?Sized>(
     target: Amount,
     fee_rate: FeeRate,
-    weighted_utxos: &'a [Utxo],
+    weighted_utxos: &'a [WeightedUtxo],
     rng: &mut R,
-) -> Return<'a, Utxo> {
+) -> Return<'a> {
     let available_value = weighted_utxos
         .iter()
         .map(|u| u.effective_value(fee_rate).unwrap_or(SignedAmount::ZERO))


### PR DESCRIPTION
Instead of generic params, use concrete type.