### PR TITLE
selection: remove overflow check during subtraction in effective_value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub(crate) fn effective_value(
     value: Amount,
 ) -> Option<SignedAmount> {
     let signed_input_fee: SignedAmount = fee_rate.fee_wu(weight)?.to_signed();
-    value.to_signed().checked_sub(signed_input_fee)
+    let eff_value = (value.to_signed() - signed_input_fee).unwrap();
+    Some(eff_value)
 }
 
 #[derive(Debug, Clone, PartialEq, Ord, Eq, PartialOrd)]


### PR DESCRIPTION
The smallest that `value` can be is zero since it's is passed in as unsigned.  When the `fee` is subtracted from `value`, the most that can be subtracted is `SignedAmount::MAX`.  Subtracting `SignedAmount::MAX` from zero results in `SignedAmount::MIN` which does not overflow.