### PR TITLE
algo: bnb: modify secondary `UTXO` sort order

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -186,9 +186,9 @@ pub fn select_coins_bnb<Utxo: WeightedUtxo>(
         .map(|(eff_val, waste, wu)| (eff_val.to_unsigned().unwrap(), waste, wu))
         .collect();
 
-    // descending sort by effective_value using satisfaction weight as tie breaker.
+    // descending sort by effective_value, ascending by waste.
     w_utxos.sort_by(|a, b| {
-        b.0.cmp(&a.0).then(b.2.satisfaction_weight().cmp(&a.2.satisfaction_weight()))
+        b.0.cmp(&a.0).then(a.2.waste(fee_rate, long_term_fee_rate).cmp(&b.2.waste(fee_rate, long_term_fee_rate)))
     });
 
     let mut available_value = w_utxos.clone().into_iter().map(|(ev, _, _)| ev).checked_sum()?;


### PR DESCRIPTION
When fee-rate is high, using waste instead of weight creates an optimal sort order, leading to an optimal  solutions being found in less iterations.

The secondary sort order is used as a tie breaker when effective_values are equivalent.  Therefore, this optimization only is relevant given a pool with equivalent effective_values yet different waste scores.

When fee_rates are high, it's optimal to secondary sort by descending weight, and when fee_rates are low, it's optimal to secondary sort by ascending weight.  However, using a secondary sort by waste, it's always optimal to sort by ascending waste.

Consider the test `select_coins_bnb_effective_value_tie_high_fee_rate`. The optimal solution will be to use `UTXOs` with a lower weight when fee_rate is high.  The previous sort by descending weight gives

```
56/112 waste: 3
55/70 waste: 2
55/70 waste: 2
```

This leads to an un-optimal selection given the last two compose the optimal solution.  The optimal solution is still found, however not until the 7th iteration.

```
     []
    /
 56/112
  /
55/70
```

The solution is recorded here after the second iteration.  Next 55/70 is moved to the exclusion branch, however the next `UTXO` 55/70 is skipped because of the `UTXO` exclusion short-cut.  It's only after `56/112` is moved to the exclusion branch that the optimal solution is found

```
   []
     \
     56/112
      /
    55/70
     /
  55/70
```

By contrast, if the secondary sort is by waste, the optimal solution is found on the second iteration.

```
      []
     /
  55/70
   /
55/70
```