### PR TITLE
test: remove invalid UTXOs from prop-test result

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -929,9 +929,7 @@ mod tests {
                 utxos.clone().into_iter().map(|u| (u.value(), u.weight()));
             // swap lt_fee_rate and fee_rate position.
             let utxos_b: Vec<WeightedUtxo> = utxo_selection_attributes
-                .map(|(amt, weight)| {
-                    WeightedUtxo::new(amt, weight, fee_rate_b, fee_rate_a).unwrap()
-                })
+                .filter_map(|(amt, weight)| WeightedUtxo::new(amt, weight, fee_rate_b, fee_rate_a))
                 .collect();
             let result_b = select_coins_bnb(target, cost_of_change, &utxos_b);
 


### PR DESCRIPTION
Once the fee-rate's are swapped, the `WeightedUtxo `constructor can return `NONE`, for example if the effective_value is not positive.  This would cause a panic in the test, therefore use `filter_map()` to filter those that return `NONE` and remove `unwrap()`.