### PR TITLE
test: improve upper bound test case

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -727,7 +727,7 @@ mod tests {
             fee_rate: "0",
             lt_fee_rate: "0",
             max_weight: "40000 wu",
-            weighted_utxos: &["2100000000000000 sats/68 vB", "1 sats/68 vB"], // [Amount::MAX, ,,]
+            weighted_utxos: &["e(1 sats)/68 vB"],
             expected_utxos: &[],
             expected_error: Some(Overflow(Addition)),
             expected_iterations: 0,


### PR DESCRIPTION
The test uses an invalid pool that would overflow when the inputs are added together.  Therefore the test could fail due to an overflow in the `UTXO` pool and not when evaluating the upper bound depending on the order of evaluation.  This change creates a valid pool showing that the overflow is due to an invalid upper bound.