### PR TITLE
deps: remove unused feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.63.0"
 
 [dependencies]
-bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "806b34aefc554c23cec2d1293113a589718c8cdf", features = ["arbitrary"] }
+bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "806b34aefc554c23cec2d1293113a589718c8cdf" }
 rand = { version = "0.8.5", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Arbitrary is only used in the test-suit, therefore remove the feature from the dependencies.