### PR TITLE
docs: update benchmark measurments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ A basic performance comparison between implementations using commodity hardware 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
 |      Rust SRD|    1,000| 22,446|
-|      Rust BnB|    1,000|605,960|
+|      Rust BnB|    1,000|431.750|
 |  C++ Core BnB|    1,000|816,374|
 
-Note: The measurements where recorded using rustc 1.90.  Expect worse performance with MSRV.
+Note: The measurements where recorded using rustc 1.91.  Expect worse performance with MSRV.
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
Significant perf improvement on nightly:
`nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.91.0-nightly (898aff704 2025-08-14)`