### PR TITLE
docs: update benchmark for `1.89` stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ A basic performance comparison between implementations using commodity hardware 
 |implementation|pool size|ns/iter|
 |-------------:|---------|-------|
 |      Rust SRD|    1,000| 22,446|
-|      Rust BnB|    1,000|605,960|
+|      Rust BnB|    1,000|582.180|
 |  C++ Core BnB|    1,000|816,374|
 
-Note: The measurements where recorded using rustc 1.90.  Expect worse performance with MSRV.
+Note: The measurements where recorded using rustc 1.89 stable.  Expect worse performance with MSRV.
 
 ## Minimum Supported Rust Version (MSRV)
 


### PR DESCRIPTION
The previous measurments where using `1.90` unstable (nightly) which is subject to change.