### PR TITLE
refactor:fuzz: rename struct from UtxoPool to CandidateOutputs

### DIFF
--- a/fuzz/fuzz_targets/select_coins.rs
+++ b/fuzz/fuzz_targets/select_coins.rs
@@ -2,9 +2,9 @@
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin_coin_selection::select_coins;
-use bitcoin_coin_selection_fuzz::UtxoPool;
 use bitcoin_units::{Amount, Weight};
 use libfuzzer_sys::fuzz_target;
+use bitcoin_coin_selection_fuzz::CandidateOutputs;
 
 fuzz_target!(|data: &[u8]| {
     let mut u = Unstructured::new(&data);
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
     let target = Amount::arbitrary(&mut u).unwrap();
     let cost_of_change = Amount::arbitrary(&mut u).unwrap();
     let max_weight = Weight::arbitrary(&mut u).unwrap();
-    let pool = UtxoPool::arbitrary(&mut u).unwrap();
+    let candidates = CandidateOutputs::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins(target, cost_of_change, max_weight, &pool.utxos);
+    let _ = select_coins(target, cost_of_change, max_weight, &candidates.utxos);
 });

--- a/fuzz/fuzz_targets/select_coins_bnb.rs
+++ b/fuzz/fuzz_targets/select_coins_bnb.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin_coin_selection::select_coins_bnb;
-use bitcoin_coin_selection_fuzz::UtxoPool;
+use bitcoin_coin_selection_fuzz::CandidateOutputs;
 use bitcoin_units::{Amount, Weight};
 use libfuzzer_sys::fuzz_target;
 
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
     let target = Amount::arbitrary(&mut u).unwrap();
     let cost_of_change = Amount::arbitrary(&mut u).unwrap();
     let max_weight = Weight::arbitrary(&mut u).unwrap();
-    let pool = UtxoPool::arbitrary(&mut u).unwrap();
+    let candidates = CandidateOutputs::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins_bnb(target, cost_of_change, max_weight, &pool.utxos);
+    let _ = select_coins_bnb(target, cost_of_change, max_weight, &candidates.utxos);
 });

--- a/fuzz/fuzz_targets/select_coins_srd.rs
+++ b/fuzz/fuzz_targets/select_coins_srd.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitcoin_coin_selection::select_coins_srd;
-use bitcoin_coin_selection_fuzz::UtxoPool;
+use bitcoin_coin_selection_fuzz::CandidateOutputs;
 use bitcoin_units::{Amount, Weight};
 use libfuzzer_sys::fuzz_target;
 use rand::thread_rng;
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
 
     let target = Amount::arbitrary(&mut u).unwrap();
     let max_weight = Weight::arbitrary(&mut u).unwrap();
-    let pool = UtxoPool::arbitrary(&mut u).unwrap();
+    let candidates = CandidateOutputs::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins_srd(target, max_weight, &pool.utxos, &mut thread_rng());
+    let _ = select_coins_srd(target, max_weight, &candidates.utxos, &mut thread_rng());
 });

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -3,11 +3,11 @@ use bitcoin_coin_selection::WeightedUtxo;
 use bitcoin_units::{Amount, FeeRate, Weight};
 
 #[derive(Debug)]
-pub struct UtxoPool {
+pub struct CandidateOutputs {
     pub utxos: Vec<WeightedUtxo>,
 }
 
-impl<'a> Arbitrary<'a> for UtxoPool {
+impl<'a> Arbitrary<'a> for CandidateOutputs {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let init: Vec<(Amount, Weight)> = Vec::arbitrary(u)?;
         let fee_rate = FeeRate::arbitrary(u).unwrap();
@@ -17,6 +17,6 @@ impl<'a> Arbitrary<'a> for UtxoPool {
             .filter_map(|i| WeightedUtxo::new(i.0, i.1, fee_rate, lt_fee_rate))
             .collect();
 
-        Ok(UtxoPool { utxos })
+        Ok(CandidateOutputs { utxos })
     }
 }


### PR DESCRIPTION
Naming this to `CandidateOutputs` is more closely aligned to what this struct is.  This also keeps the name `UtxoPool` free for use elsewhere without conflict.