### PR TITLE
refactor:test: rename test struct from UtxoPool to SelectionCandidate

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -341,7 +341,7 @@ mod tests {
     use bitcoin_units::{Amount, CheckedSum, FeeRate, Weight};
 
     use super::*;
-    use crate::tests::{assert_ref_eq, parse_fee_rate, UtxoPool};
+    use crate::tests::{assert_ref_eq, parse_fee_rate, SelectionCandidate};
     use crate::SelectionError::ProgramError;
     use crate::WeightedUtxo;
 
@@ -368,16 +368,16 @@ mod tests {
             let max_weight: Vec<_> = self.max_weight.split(" ").collect();
             let max_weight = Weight::from_str(max_weight[0]).unwrap();
 
-            let pool: UtxoPool = UtxoPool::new(self.weighted_utxos, fee_rate, lt_fee_rate);
+            let candidate = SelectionCandidate::new(self.weighted_utxos, fee_rate, lt_fee_rate);
 
-            let result = select_coins_bnb(target, cost_of_change, max_weight, &pool.utxos);
+            let result = select_coins_bnb(target, cost_of_change, max_weight, &candidate.utxos);
 
             match result {
                 Ok((iterations, inputs)) => {
                     assert_eq!(iterations, self.expected_iterations);
-                    let expected =
-                        UtxoPool::new(self.expected_utxos, fee_rate, lt_fee_rate);
-                    assert_ref_eq(inputs, expected.utxos);
+                    let candidate =
+                        SelectionCandidate::new(self.expected_utxos, fee_rate, lt_fee_rate);
+                    assert_ref_eq(inputs, candidate.utxos);
                 }
                 Err(e) => {
                     let expected_error = self.expected_error.clone().unwrap();
@@ -392,7 +392,7 @@ mod tests {
         target: Amount,
         cost_of_change: Amount,
         max_weight: Weight,
-        pool: UtxoPool,
+        candidate: SelectionCandidate,
         expected_inputs: Vec<WeightedUtxo>,
     }
 
@@ -401,12 +401,12 @@ mod tests {
             let target = self.target;
             let cost_of_change = self.cost_of_change;
             let max_weight = self.max_weight;
-            let pool = &self.pool;
-            let inputs = &pool.utxos;
+            let candidate = &self.candidate;
+            let utxos = &candidate.utxos;
             let expected_inputs = self.expected_inputs;
 
             let upper_bound = target.checked_add(cost_of_change);
-            let result = select_coins_bnb(target, cost_of_change, max_weight, inputs);
+            let result = select_coins_bnb(target, cost_of_change, max_weight, utxos);
 
             match result {
                 Ok((i, utxos)) => {
@@ -414,13 +414,13 @@ mod tests {
                     crate::tests::assert_target_selection(&utxos, target, upper_bound);
                 }
                 Err(InsufficentFunds) => {
-                    let available_value = pool.available_value().unwrap();
+                    let available_value = candidate.available_value().unwrap();
                     assert!(available_value < target);
                 }
                 Err(IterationLimitReached) => {}
                 Err(Overflow(_)) => {
-                    let available_value = pool.available_value();
-                    let weight_total = pool.weight_total();
+                    let available_value = candidate.available_value();
+                    let weight_total = candidate.weight_total();
                     assert!(
                         available_value.is_none()
                             || weight_total.is_none()
@@ -431,7 +431,7 @@ mod tests {
                 Err(SolutionNotFound) =>
                     assert!(expected_inputs.is_empty() || target == Amount::ZERO),
                 Err(MaxWeightExceeded) => {
-                    let weight_total = pool.weight_total().unwrap();
+                    let weight_total = candidate.weight_total().unwrap();
                     assert!(weight_total > max_weight);
                 }
             }
@@ -474,14 +474,14 @@ mod tests {
                     WeightedUtxo::new(*amt, *weight, fee_rate, long_term_fee_rate)
                 })
                 .collect();
-            let pool = UtxoPool { utxos, fee_rate, long_term_fee_rate };
+            let candidate = SelectionCandidate { utxos, fee_rate, long_term_fee_rate };
 
             let target_set: Vec<_> = expected_inputs.iter().map(|u| u.effective_value()).collect();
 
             let target: Amount =
                 target_set.clone().into_iter().checked_sum().unwrap_or(Amount::ZERO);
 
-            Ok(AssertBnB { target, cost_of_change, max_weight, pool, expected_inputs })
+            Ok(AssertBnB { target, cost_of_change, max_weight, candidate, expected_inputs })
         }
     }
 
@@ -1030,13 +1030,13 @@ mod tests {
     #[test]
     fn select_coins_bnb_thrifty_proptest() {
         arbtest(|u| {
-            let pool = UtxoPool::arbitrary(u)?;
+            let candidate = SelectionCandidate::arbitrary(u)?;
             let target = Amount::arbitrary(u)?;
             let cost_of_change = Amount::arbitrary(u)?;
-            let fee_rate_a = pool.fee_rate;
-            let fee_rate_b = pool.long_term_fee_rate;
+            let fee_rate_a = candidate.fee_rate;
+            let fee_rate_b = candidate.long_term_fee_rate;
             let max_weight = Weight::MAX;
-            let utxos = pool.utxos;
+            let utxos = candidate.utxos;
 
             let result_a = select_coins_bnb(target, cost_of_change, max_weight, &utxos);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ mod tests {
         upper_bound: Option<Amount>,
     ) {
         let utxos: Vec<WeightedUtxo> = utxos.iter().map(|&u| u.clone()).collect();
-        let eff_value_sum = UtxoPool::effective_value_sum(&utxos).unwrap();
+        let eff_value_sum = SelectionCandidate::effective_value_sum(&utxos).unwrap();
         assert!(eff_value_sum >= target);
 
         if let Some(ub) = upper_bound {
@@ -243,13 +243,13 @@ mod tests {
     }
 
     #[derive(Debug)]
-    pub struct UtxoPool {
+    pub struct SelectionCandidate {
         pub utxos: Vec<WeightedUtxo>,
         pub fee_rate: FeeRate,
         pub long_term_fee_rate: FeeRate,
     }
 
-    impl<'a> Arbitrary<'a> for UtxoPool {
+    impl<'a> Arbitrary<'a> for SelectionCandidate {
         fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
             let init: Vec<(Amount, Weight)> = Vec::arbitrary(u)?;
             let fee_rate = FeeRate::arbitrary(u)?;
@@ -259,7 +259,7 @@ mod tests {
                 .filter_map(|i| WeightedUtxo::new(i.0, i.1, fee_rate, long_term_fee_rate))
                 .collect();
 
-            Ok(UtxoPool { utxos, fee_rate, long_term_fee_rate })
+            Ok(SelectionCandidate { utxos, fee_rate, long_term_fee_rate })
         }
     }
 
@@ -274,8 +274,12 @@ mod tests {
         }
     }
 
-    impl UtxoPool {
-        pub fn new(utxos: &[&str], fee_rate: FeeRate, long_term_fee_rate: FeeRate) -> UtxoPool {
+    impl SelectionCandidate {
+        pub fn new(
+            utxos: &[&str],
+            fee_rate: FeeRate,
+            long_term_fee_rate: FeeRate,
+        ) -> SelectionCandidate {
             let utxos: Vec<_> = utxos
                 .iter()
                 .filter_map(|u| {
@@ -295,7 +299,7 @@ mod tests {
                 })
                 .collect();
 
-            UtxoPool { utxos, fee_rate, long_term_fee_rate }
+            SelectionCandidate { utxos, fee_rate, long_term_fee_rate }
         }
 
         fn effective_value_sum(utxos: &[WeightedUtxo]) -> Option<Amount> {
@@ -393,12 +397,12 @@ mod tests {
     #[test]
     fn select_coins_proptest() {
         arbtest(|u| {
-            let pool = UtxoPool::arbitrary(u)?;
+            let candidate = SelectionCandidate::arbitrary(u)?;
             let target = Amount::arbitrary(u)?;
             let cost_of_change = Amount::arbitrary(u)?;
             let max_weight = Weight::arbitrary(u)?;
 
-            let utxos = pool.utxos.clone();
+            let utxos = candidate.utxos.clone();
             let result = select_coins(target, cost_of_change, max_weight, &utxos);
 
             match result {
@@ -407,12 +411,12 @@ mod tests {
                     crate::tests::assert_target_selection(&utxos, target, None);
                 }
                 Err(InsufficentFunds) => {
-                    let available_value = pool.available_value().unwrap();
+                    let available_value = candidate.available_value().unwrap();
                     assert!(available_value < (target + CHANGE_LOWER).unwrap());
                 }
                 Err(Overflow(_)) => {
-                    let available_value = pool.available_value();
-                    let weight_total = pool.weight_total();
+                    let available_value = candidate.available_value();
+                    let weight_total = candidate.weight_total();
                     assert!(
                         available_value.is_none()
                             || weight_total.is_none()

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -110,7 +110,7 @@ mod tests {
 
     use super::*;
     use crate::single_random_draw::select_coins_srd;
-    use crate::tests::{assert_ref_eq, parse_fee_rate, UtxoPool};
+    use crate::tests::{assert_ref_eq, parse_fee_rate, SelectionCandidate};
 
     #[derive(Debug)]
     pub struct TestSRD<'a> {
@@ -131,15 +131,15 @@ mod tests {
             let max_weight: Vec<_> = self.max_weight.split(" ").collect();
             let max_weight = Weight::from_str(max_weight[0]).unwrap();
 
-            let pool = UtxoPool::new(self.weighted_utxos, fee_rate, lt_fee_rate);
+            let candidate = SelectionCandidate::new(self.weighted_utxos, fee_rate, lt_fee_rate);
 
-            let result = select_coins_srd(target, max_weight, &pool.utxos, &mut get_rng());
+            let result = select_coins_srd(target, max_weight, &candidate.utxos, &mut get_rng());
 
             match result {
                 Ok((iterations, inputs)) => {
                     assert_eq!(iterations, self.expected_iterations);
-                    let expected: UtxoPool =
-                        UtxoPool::new(self.expected_utxos, fee_rate, lt_fee_rate);
+                    let expected =
+                        SelectionCandidate::new(self.expected_utxos, fee_rate, lt_fee_rate);
                     assert_ref_eq(inputs, expected.utxos);
                 }
                 Err(e) => {
@@ -358,11 +358,11 @@ mod tests {
     #[test]
     fn select_coins_srd_proptest() {
         arbtest(|u| {
-            let pool = UtxoPool::arbitrary(u)?;
+            let candidate = SelectionCandidate::arbitrary(u)?;
             let target = Amount::arbitrary(u)?;
             let max_weight = Weight::arbitrary(u)?;
 
-            let utxos = pool.utxos.clone();
+            let utxos = candidate.utxos.clone();
             let result: Result<_, _> = select_coins_srd(target, max_weight, &utxos, &mut get_rng());
 
             match result {
@@ -371,17 +371,17 @@ mod tests {
                     crate::tests::assert_target_selection(&utxos, target, None);
                 }
                 Err(InsufficentFunds) => {
-                    let available_value = pool.available_value().unwrap();
+                    let available_value = candidate.available_value().unwrap();
                     assert!(available_value < (target + CHANGE_LOWER).unwrap());
                 }
                 Err(crate::SelectionError::IterationLimitReached) => panic!("un-expected result"),
                 Err(MaxWeightExceeded) => {
-                    let weight_total = pool.weight_total().unwrap();
+                    let weight_total = candidate.weight_total().unwrap();
                     assert!(weight_total > max_weight);
                 }
                 Err(Overflow(_)) => {
-                    let available_value = pool.available_value();
-                    let weight_total = pool.weight_total();
+                    let available_value = candidate.available_value();
+                    let weight_total = candidate.weight_total();
                     assert!(
                         available_value.is_none()
                             || weight_total.is_none()


### PR DESCRIPTION
Naming this to `SelectionCandidate` is more closely aligned to what this struct is.  This also keeps the name `UtxoPool` free for use elsewhere without conflict.