### PR TITLE
docs: fix build problem on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["bitcoin", "coin-selection", "coin", "coinselection", "utxo"]
 readme = "README.md"
 rust-version = "1.63.0"
 
+[package.metadata.docs.rs]
+features = ["rand"]
+
 [dependencies]
 bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "806b34aefc554c23cec2d1293113a589718c8cdf" }
 rand = { version = "0.8.5", default-features = false, optional = true }


### PR DESCRIPTION
The docs page on docs.rs does not build, and the build logs show it fails due to missing the rand dependence.