### PR TITLE
algo: move reference to selection candidates to last positional argument

### DIFF
--- a/benches/srd_selection.rs
+++ b/benches/srd_selection.rs
@@ -16,7 +16,7 @@ pub fn srd_benchmark(c: &mut Criterion) {
     c.bench_function("srd", |b| {
         b.iter(|| {
             let (iteration_count, inputs) =
-                select_coins_srd(target, max_weight, &utxos, &mut thread_rng()).unwrap();
+                select_coins_srd(target, max_weight, &mut thread_rng(), &utxos).unwrap();
             assert_eq!(iteration_count, 1_000);
             assert_eq!(inputs.len(), 1_000);
         })

--- a/fuzz/fuzz_targets/select_coins_srd.rs
+++ b/fuzz/fuzz_targets/select_coins_srd.rs
@@ -14,5 +14,5 @@ fuzz_target!(|data: &[u8]| {
     let max_weight = Weight::arbitrary(&mut u).unwrap();
     let candidates = CandidateOutputs::arbitrary(&mut u).unwrap();
 
-    let _ = select_coins_srd(target, max_weight, &candidates.utxos, &mut thread_rng());
+    let _ = select_coins_srd(target, max_weight, &mut thread_rng(), &candidates.utxos);
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub fn select_coins(
     let bnb_result = select_coins_bnb(target, cost_of_change, max_weight, weighted_utxos);
 
     if bnb_result.is_err() {
-        select_coins_srd(target, max_weight, weighted_utxos, &mut thread_rng())
+        select_coins_srd(target, max_weight, &mut thread_rng(), weighted_utxos)
     } else {
         bnb_result
     }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -23,8 +23,8 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 /// * `target` - target value to send to recipient.  Include the fee to pay for
 ///   the known parts of the transaction excluding the fee for the inputs.
 /// * `max_weight` - the maximum selection `Weight` allowed.
-/// * `weighted_utxos` - Weighted UTXOs from which to sum the target amount.
 /// * `rng` - used primarily by tests to make the selection deterministic.
+/// * `weighted_utxos` - Weighted UTXOs from which to sum the target amount.
 ///
 /// # Errors
 ///
@@ -34,8 +34,8 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 pub fn select_coins_srd<'a, R: rand::Rng + ?Sized>(
     target: Amount,
     max_weight: Weight,
-    weighted_utxos: &'a [WeightedUtxo],
     rng: &mut R,
+    weighted_utxos: &'a [WeightedUtxo],
 ) -> Return<'a> {
     let _ = weighted_utxos
         .iter()
@@ -133,8 +133,7 @@ mod tests {
 
             let candidate_selection = Selection::new(self.weighted_utxos, fee_rate, lt_fee_rate);
 
-            let result =
-                select_coins_srd(target, max_weight, &candidate_selection.utxos, &mut get_rng());
+            let result = select_coins_srd(target, max_weight, &mut get_rng(), &candidate_selection.utxos);
 
             match result {
                 Ok((iterations, inputs)) => {
@@ -366,7 +365,7 @@ mod tests {
             let max_weight = Weight::arbitrary(u)?;
 
             let utxos = candidate.utxos.clone();
-            let result: Result<_, _> = select_coins_srd(target, max_weight, &utxos, &mut get_rng());
+            let result: Result<_, _> = select_coins_srd(target, max_weight, &mut get_rng(), &utxos);
 
             match result {
                 Ok((i, utxos)) => {


### PR DESCRIPTION
Use the same positional order of parameters for every selection algorithm.