### PR TITLE
docs: remove redundant information

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -29,16 +29,6 @@ pub const ITERATION_LIMIT: u32 = 100_000;
 /// * cost_of_change: The `Amount` needed to produce a change output
 /// * max_weight: the maximum selection `Weight` allowed.
 /// * weighted_utxos: The candidate Weighted UTXOs from which to choose a selection from
-///
-/// # Returns
-///
-/// The best solution found and the number of iterations to find it.  Note that if the iteration
-/// count equals `ITERATION_LIMIT`, a better solution may exist than the one found.
-///
-/// # Errors
-///
-/// If an arithmetic overflow occurs, a solution is not present, the target can't be reached or if
-/// the iteration limit is hit.
 // This search explores a binary tree.  The left branch of each node is the inclusion branch and
 // the right branch is the exclusion branch.
 //      o

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -25,12 +25,6 @@ use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 /// * `max_weight` - the maximum selection `Weight` allowed.
 /// * `rng` - used primarily by tests to make the selection deterministic.
 /// * `weighted_utxos` - Weighted UTXOs from which to sum the target amount.
-///
-/// # Errors
-///
-/// If an arithmetic overflow occurs, the target can't be reached, or an un-expected error occurs.
-/// Note that if sufficient funds are supplied, and an overflow does not occur, then a solution
-/// should always be found.  Anything else would be an un-expected program error.
 pub fn single_random_draw<'a, R: rand::Rng + ?Sized>(
     target: Amount,
     max_weight: Weight,


### PR DESCRIPTION
The errors section is unneeded since one needs only match on the potential error.

The Returns section is also redundant since one can simply read the description for algorithm behavior.