### PR TITLE
fuzz: match parent crate dependencies

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 rand = "0.8.5"
-bitcoin-units = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "806b34aefc554c23cec2d1293113a589718c8cdf", features = ["arbitrary"] }
+bitcoin-units = { version = "1.0.0-rc.0", features = ["arbitrary"] }
 arbitrary = { version = "1", features = ["derive"] }
 
 [dependencies.bitcoin-coin-selection]


### PR DESCRIPTION
Fuzz tests fail to run if the fuzz crate uses a different version of bitcoin-units than the parent crate.