### PR TITLE
dependencies: specify rand minor version omitting patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ features = ["rand"]
 
 [dependencies]
 bitcoin-units = "1.0.0-rc.0"
-rand = { version = "0.8.5", optional = true }
+rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
 bitcoin-units = { version = "1.0.0-rc.0", features = ["arbitrary"] }
 criterion = "0.6"
 bitcoin-coin-selection = { path = ".", features = ["rand"] }
-rand = "0.8.5"
+rand = "0.8"
 arbitrary = { version = "1", features = ["derive"] }
 arbtest = "0.3.1"
 exhaustigen = "0.1.0"


### PR DESCRIPTION
There is no reason to dictate the patch version here.