### PR TITLE
reactor: remove deprecated function fee_wu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub(crate) fn effective_value(
     weight: Weight,
     value: Amount,
 ) -> Option<SignedAmount> {
-    let signed_input_fee: SignedAmount = fee_rate.fee_wu(weight)?.to_signed();
+    let signed_input_fee: SignedAmount = fee_rate.to_fee(weight).to_signed();
     let eff_value = (value.to_signed() - signed_input_fee).unwrap();
     Some(eff_value)
 }

--- a/src/weighted_utxo.rs
+++ b/src/weighted_utxo.rs
@@ -34,8 +34,8 @@ impl WeightedUtxo {
         let positive_effective_value = Self::positive_effective_value(fee_rate, weight, value);
 
         if let Some(effective_value) = positive_effective_value {
-            let fee = fee_rate.fee_wu(weight)?.to_signed();
-            let long_term_fee: SignedAmount = long_term_fee_rate.fee_wu(weight)?.to_signed();
+            let fee = fee_rate.to_fee(weight).to_signed();
+            let long_term_fee: SignedAmount = long_term_fee_rate.to_fee(weight).to_signed();
             let waste = Self::calculate_waste(fee, long_term_fee);
             return Some(Self { value, weight, effective_value, fee, long_term_fee, waste });
         }


### PR DESCRIPTION
Besides the change of name to `to_fee`, now the function no longer returns results wrapped in an option, so the `?` operator is removed as well.