### PR TITLE
docs: correct wording of SRD algo

### DIFF
--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -15,12 +15,13 @@ use crate::OverflowError::Addition;
 use crate::SelectionError::{InsufficentFunds, MaxWeightExceeded, Overflow, ProgramError};
 use crate::{Return, WeightedUtxo, CHANGE_LOWER};
 
-/// Randomized single round selection.
+/// Select coins by Single Random Draw (SRD).
 ///
-/// This algorithm works by selecting inputs randomly until the target amount is reached or
-/// exceeded.  If the maximum weight is exceeded, then the least valuable inputs are removed from
-/// the selection using weight as a tie breaker.  In so doing, minimize the number of `UTXOs`
-/// included in the result by preferring UTXOs with higher value.
+/// SRD selects eligible Outputs from a shuffled ordering until the effective value of the input
+/// set suffices to create the recipient outputs and a change output with an amount of at least
+/// `CHANGE_LOWER`. While the maximum selection weight is exceeded during selection, the Output with
+/// the lowest effective value is dropped from the selection before additional Output are selected.
+/// Due to this greedy approach, SRD can fail to discover possible solutions in pathological cases.
 ///
 /// # Parameters
 ///

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -102,9 +102,6 @@ pub fn single_random_draw<
     if max_tx_weight_exceeded {
         Err(MaxWeightExceeded)
     } else {
-        // This should never be reached.
-        // Either there is not enough funds, or an overflow occurred.
-        // If neither of those two things occurred, then a solution should be found.
         Err(ProgramError)
     }
 }


### PR DESCRIPTION
The previous description was misleading in that it stated that the number of UTXOs in the selection result are minimized.  The reason this is not always true is that outputs are removed when weight is exceeded, however the removed outputs are removed by `effective_value`.  That is, the threshold is a function of weight, however the eviction strategy is a function of effective_value.  Since the ordering is randomized, the weight may be exceeded, and a high weight UTXO may be removed, then multiple lower weight UTXOs added in it's place effectively increasing the selection size.

Also, add clause that there is the pathological case where a solution may exist, and yet none is found due to the greedy selection strategy of evicting the lowest effective value UTXO.

Lastly, mention behavior of `CHANGE_LOWER` as a minimum threshold for finding a solution.

closes: https://github.com/p2pderivatives/rust-bitcoin-coin-selection/issues/230