### PR TITLE
dependency: bump rand version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ features = ["rand"]
 
 [dependencies]
 bitcoin-units = "1.0.0-rc.0"
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 
 [dev-dependencies]
 bitcoin-units = { version = "1.0.0-rc.0", features = ["arbitrary"] }
 criterion = "0.6"
-bitcoin-coin-selection = { path = ".", features = ["rand"] }
-rand = "0.8"
+bitcoin-coin-selection = {path = ".", features = ["rand"]}
+rand = "0.9"
 arbitrary = { version = "1", features = ["derive"] }
 arbtest = "0.3.1"
 exhaustigen = "0.1.0"

--- a/benches/srd_selection.rs
+++ b/benches/srd_selection.rs
@@ -1,7 +1,7 @@
 use bitcoin_coin_selection::{single_random_draw, WeightedUtxo};
 use bitcoin_units::{Amount, FeeRate, Weight};
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
+use rand::rng;
 
 pub fn srd_benchmark(c: &mut Criterion) {
     let fee_rate = FeeRate::from_sat_per_kwu(10);
@@ -16,7 +16,7 @@ pub fn srd_benchmark(c: &mut Criterion) {
     c.bench_function("srd", |b| {
         b.iter(|| {
             let (iteration_count, inputs) =
-                single_random_draw(target, max_weight, &mut thread_rng(), &utxos).unwrap();
+                single_random_draw(target, max_weight, &mut rng(), &utxos).unwrap();
             assert_eq!(iteration_count, 1_000);
             assert_eq!(inputs.len(), 1_000);
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod errors;
 use bitcoin_units::{Amount, FeeRate, SignedAmount, Weight};
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-use rand::thread_rng;
+use rand::rng;
 
 pub use crate::branch_and_bound::branch_and_bound;
 pub use crate::coin_grinder::coin_grinder;
@@ -97,7 +97,7 @@ pub fn select_coins<'a, T: IntoIterator<Item = &'a WeightedUtxo> + std::marker::
     let bnb_result = branch_and_bound(target, cost_of_change, max_weight, weighted_utxos);
 
     if bnb_result.is_err() {
-        single_random_draw(target, max_weight, &mut thread_rng(), weighted_utxos)
+        single_random_draw(target, max_weight, &mut rng(), weighted_utxos)
     } else {
         bnb_result
     }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -115,11 +115,13 @@ mod tests {
     use arbitrary::Arbitrary;
     use arbtest::arbtest;
     use bitcoin_units::Amount;
-    use rand::rngs::mock::StepRng;
-
+    
     use super::*;
     use crate::single_random_draw::single_random_draw;
     use crate::tests::{assert_ref_eq, parse_fee_rate, Selection};
+
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
 
     #[derive(Debug)]
     pub struct TestSRD<'a> {
@@ -174,7 +176,7 @@ mod tests {
         .assert();
     }
 
-    fn get_rng() -> StepRng {
+    fn get_rng() -> SmallRng {
         // [1, 2]
         // let mut vec: Vec<u32> = (1..3).collect();
         // let mut rng = StepRng::new(0, 0);
@@ -185,7 +187,7 @@ mod tests {
         // shuffle() will always result in the order described above when a constant
         // is used as the rng.  The first is removed from the beginning and added to
         // the end while the remaining elements keep their order.
-        StepRng::new(0, 0)
+        SmallRng::seed_from_u64(1)
     }
 
     #[test]


### PR DESCRIPTION
`StepRng` is now deprecated, so replace with `SmallRng` using `seed_from_u64(1)` to produce deterministic tests.