### PR TITLE
api: change weight to total_weight

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -154,7 +154,7 @@ pub fn branch_and_bound<'a, T: IntoIterator<Item = &'a WeightedUtxo> + std::mark
 
     let _ = weighted_utxos
         .into_iter()
-        .map(|u| u.weight())
+        .map(|u| u.total_weight())
         .try_fold(Weight::ZERO, Weight::checked_add)
         .ok_or(Overflow(Addition))?;
 
@@ -269,7 +269,7 @@ fn bnb_select(
             assert_eq!(index, *index_selection.last().unwrap());
             let eff_value = weighted_utxos[index].effective_value_raw();
             let utxo_waste = weighted_utxos[index].waste_raw();
-            let utxo_weight = weighted_utxos[index].weight();
+            let utxo_weight = weighted_utxos[index].total_weight();
             current_waste = current_waste.checked_sub(utxo_waste).ok_or(Overflow(Subtraction))?;
             value = value.checked_sub(eff_value).ok_or(Overflow(Addition))?;
             weight -= utxo_weight;
@@ -278,7 +278,7 @@ fn bnb_select(
         // * Add next node to the inclusion branch.
         else {
             let eff_value = weighted_utxos[index].effective_value_raw();
-            let utxo_weight = weighted_utxos[index].weight();
+            let utxo_weight = weighted_utxos[index].total_weight();
             let utxo_waste = weighted_utxos[index].waste_raw();
 
             // unchecked sub is used her for performance.
@@ -1008,7 +1008,7 @@ mod tests {
             let result_a = branch_and_bound(target, cost_of_change, max_weight, &utxos);
 
             let utxo_selection_attributes =
-                utxos.clone().into_iter().map(|u| (u.value(), u.weight()));
+                utxos.clone().into_iter().map(|u| (u.value(), u.total_weight()));
             // swap lt_fee_rate and fee_rate position.
             let utxos_b: Vec<WeightedUtxo> = utxo_selection_attributes
                 .filter_map(|(amt, weight)| WeightedUtxo::new(amt, weight, fee_rate_b, fee_rate_a))
@@ -1019,11 +1019,11 @@ mod tests {
                 if let Ok((_, utxos_b)) = result_b {
                     let weight_sum_a = utxos_a
                         .iter()
-                        .map(|u| u.weight())
+                        .map(|u| u.total_weight())
                         .try_fold(Weight::ZERO, Weight::checked_add);
                     let weight_sum_b = utxos_b
                         .iter()
-                        .map(|u| u.weight())
+                        .map(|u| u.total_weight())
                         .try_fold(Weight::ZERO, Weight::checked_add);
 
                     if let Some(weight_a) = weight_sum_a {

--- a/src/coin_grinder.rs
+++ b/src/coin_grinder.rs
@@ -24,7 +24,7 @@ fn build_lookahead(lookahead: Vec<&WeightedUtxo>, available_value: Amount) -> Ve
 
 // Provides a lookup to determine the minimum UTXO weight after a given index.
 fn build_min_tail_weight(weighted_utxos: Vec<&WeightedUtxo>) -> Vec<Weight> {
-    let weights: Vec<_> = weighted_utxos.into_iter().map(|u| u.weight()).rev().collect();
+    let weights: Vec<_> = weighted_utxos.into_iter().map(|u| u.total_weight()).rev().collect();
     let mut prev = Weight::MAX;
     let mut result = Vec::new();
     for w in weights {
@@ -96,7 +96,7 @@ pub fn coin_grinder<'a, T: IntoIterator<Item = &'a WeightedUtxo> + std::marker::
 ) -> Return<'a> {
     weighted_utxos
         .into_iter()
-        .map(|u| u.weight())
+        .map(|u| u.total_weight())
         .try_fold(Weight::ZERO, Weight::checked_add)
         .ok_or(Overflow(Addition))?;
 
@@ -215,7 +215,7 @@ fn cg_select(
         let eff_value = utxo.effective_value();
 
         amount_total = (amount_total + eff_value).unwrap();
-        weight_total += utxo.weight();
+        weight_total += utxo.total_weight();
 
         selection.push(next_utxo_index);
         next_utxo_index += 1;
@@ -226,7 +226,7 @@ fn cg_select(
             cut = true;
         } else if weight_total > best_weight {
             weight_exceeded = true;
-            if weighted_utxos[tail].weight() <= min_tail_weight[tail] {
+            if weighted_utxos[tail].total_weight() <= min_tail_weight[tail] {
                 cut = true;
             } else {
                 shift = true;
@@ -250,7 +250,7 @@ fn cg_select(
                 best_weight,
             ) {
                 if is_higher {
-                    if weighted_utxos[tail].weight() <= min_tail_weight[tail] {
+                    if weighted_utxos[tail].total_weight() <= min_tail_weight[tail] {
                         cut = true;
                     } else {
                         shift = true;
@@ -274,7 +274,7 @@ fn cg_select(
             let eff_value = utxo.effective_value();
 
             amount_total = (amount_total - eff_value).unwrap();
-            weight_total -= utxo.weight();
+            weight_total -= utxo.total_weight();
             selection.pop();
             shift = true;
         }
@@ -291,7 +291,7 @@ fn cg_select(
             let eff_value = utxo.effective_value();
 
             amount_total = (amount_total - eff_value).unwrap();
-            weight_total -= utxo.weight();
+            weight_total -= utxo.total_weight();
             selection.pop();
 
             shift = false;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 //! Possible error types if no match is found.
 
-use crate::WeightedUtxo;
-use crate::ITERATION_LIMIT;
+use crate::{WeightedUtxo, ITERATION_LIMIT};
 
 /// Error types returned during the selection process when no match is found.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ mod weighted_utxo;
 pub use crate::weighted_utxo::WeightedUtxo;
 
 pub mod errors;
-use crate::errors::{OverflowError, SelectionError};
-
 use bitcoin_units::{Amount, FeeRate, SignedAmount, Weight};
+
+use crate::errors::{OverflowError, SelectionError};
 
 // Algorithm return types.
 pub(crate) type Return<'a> = Result<(u32, Vec<&'a WeightedUtxo>), SelectionError>;
@@ -106,13 +106,12 @@ pub fn select_coins<'a, T: IntoIterator<Item = &'a WeightedUtxo> + std::marker::
 mod tests {
     use std::str::FromStr;
 
-    use arbitrary::Arbitrary;
+    use arbitrary::{Arbitrary, Result, Unstructured};
     use arbtest::arbtest;
     use bitcoin_units::{Amount, NumOpResult, Weight};
 
     use super::*;
     use crate::SelectionError::{InsufficentFunds, Overflow, ProgramError};
-    use arbitrary::{Result, Unstructured};
 
     pub fn build_pool() -> Vec<WeightedUtxo> {
         let amts = [27_336, 238, 9_225, 20_540, 35_590, 49_463, 6_331, 35_548, 50_363, 28_009];
@@ -141,7 +140,7 @@ mod tests {
     }
 
     pub fn weight_sum(utxos: &[WeightedUtxo]) -> Option<Weight> {
-        utxos.iter().map(|u| u.weight()).try_fold(Weight::ZERO, Weight::checked_add)
+        utxos.iter().map(|u| u.total_weight()).try_fold(Weight::ZERO, Weight::checked_add)
     }
 
     pub(crate) fn parse_fee_rate(f: &str) -> FeeRate {

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -49,7 +49,7 @@ pub fn single_random_draw<
 ) -> Return<'a> {
     let _ = weighted_utxos
         .into_iter()
-        .map(|u| u.weight())
+        .map(|u| u.total_weight())
         .try_fold(Weight::ZERO, Weight::checked_add)
         .ok_or(Overflow(Addition))?;
 
@@ -93,7 +93,7 @@ fn srd_select(target: Amount, max_weight: Weight, weighted_utxos: &[&WeightedUtx
 
         value = (value + effective_value).unwrap();
 
-        let utxo_weight = w_utxo.weight();
+        let utxo_weight = w_utxo.total_weight();
         weight_total += utxo_weight;
 
         while weight_total > max_weight {
@@ -102,7 +102,7 @@ fn srd_select(target: Amount, max_weight: Weight, weighted_utxos: &[&WeightedUtx
             if let Some((utxo, _i)) = heap.pop() {
                 let effective_value = utxo.effective_value();
                 value = (value - effective_value).unwrap();
-                weight_total -= utxo.weight();
+                weight_total -= utxo.total_weight();
             };
         }
 

--- a/src/weighted_utxo.rs
+++ b/src/weighted_utxo.rs
@@ -59,8 +59,8 @@ impl WeightedUtxo {
         self.value
     }
 
-    /// Returns the associated weight.
-    pub fn weight(&self) -> Weight {
+    /// Returns the `UTXO` total weight.
+    pub fn total_weight(&self) -> Weight {
         self.weight
     }
 


### PR DESCRIPTION
Make clear that this is the total utxo weight, not satisfaction weight nor segwit weight.  This matches the definition in rust-bitcoin `InputWeightPrediction` for method `total_weight()`.