### PR TITLE
test: print error returned

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -385,9 +385,13 @@ mod tests {
                     assert_ref_eq(inputs, utxos);
                 }
                 Err(e) => {
-                    let expected_error = self.expected_error.clone().unwrap();
+                    let expected_error = self.expected_error.clone();
+                    if let Some(err) = expected_error {
+                        assert_eq!(e, err);
+                    } else {
+                        println!("got: {:?} expected {:?}", e, expected_error);
+                    }
                     assert!(self.expected_utxos.is_empty());
-                    assert_eq!(e, expected_error);
                 }
             }
         }

--- a/src/coin_grinder.rs
+++ b/src/coin_grinder.rs
@@ -369,10 +369,14 @@ mod tests {
                     assert_ref_eq(inputs, utxos);
                 }
                 Err(e) => {
-                    let expected_error = self.expected_error.clone().unwrap();
+                    let expected_error = self.expected_error.clone();
+                    if let Some(err) = expected_error {
+                        assert_eq!(e, err);
+                    } else {
+                        println!("got: {:?} expected {:?}", e, expected_error);
+                    }
                     assert!(self.expected_utxos.is_empty());
                     assert!(self.expected_iterations == 0);
-                    assert_eq!(e, expected_error);
                 }
             }
         }


### PR DESCRIPTION
if no error was expected yet an error was returned, for debugging purposes, its nice to see what the returned error is.

match behavior introduced to SRD: https://github.com/p2pderivatives/rust-bitcoin-coin-selection/commit/151f31a849d9326c76ec3a0f3bb3e96caaf1aa67