### PR TITLE
test:refactor: assert iterations are zero for errors

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -392,6 +392,7 @@ mod tests {
                         println!("got: {:?} expected {:?}", e, expected_error);
                     }
                     assert!(self.expected_utxos.is_empty());
+                    assert!(self.expected_iterations == 0);
                 }
             }
         }
@@ -804,7 +805,7 @@ mod tests {
             ],
             expected_utxos: &[],
             expected_error: Some(MaxWeightExceeded),
-            expected_iterations: 26,
+            expected_iterations: 0,
         }
         .assert();
     }

--- a/src/single_random_draw.rs
+++ b/src/single_random_draw.rs
@@ -173,6 +173,7 @@ mod tests {
                         println!("got: {:?} expected {:?}", e, expected_error);
                     }
                     assert!(self.expected_utxos.is_empty());
+                    assert!(self.expected_iterations == 0);
                 }
             }
         }
@@ -304,7 +305,7 @@ mod tests {
             weighted_utxos: &["e(3 cBTC)/68 vB", "e(5 cBTC)/10000 vB", "e(9 cBTC)/68 vB"],
             expected_utxos: &[],
             expected_error: Some(MaxWeightExceeded),
-            expected_iterations: 5,
+            expected_iterations: 0,
         }
         .assert();
     }


### PR DESCRIPTION
Error type doesn't return an iteration count