### PR TITLE
Saturate to Amont::MAX for cost_of_change

### DIFF
--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -149,7 +149,7 @@ pub fn branch_and_bound<T: Spendable>(
     let mut weighted_utxos: Vec<_> =
         WeightedUtxo::from_spendables(spendable_coins, fee_rate, long_term_fee_rate);
 
-    let upper_bound = target.checked_add(cost_of_change).ok_or(Overflow(Addition))?.to_sat();
+    let upper_bound = target.checked_add(cost_of_change).unwrap_or(Amount::MAX).to_sat();
     let available_value = SelectionError::pre_handler(target, &weighted_utxos)?;
     let target = target.to_sat();
 
@@ -624,7 +624,7 @@ mod tests {
     }
 
     #[test]
-    fn select_coins_bnb_upper_bound_overflow() {
+    fn select_coins_bnb_upper_bound_does_not_overflow() {
         // Adding cost_of_change to the target (upper bound) overflows.
         TestBnB {
             target: "1 sats",
@@ -633,9 +633,9 @@ mod tests {
             lt_fee_rate: "0",
             max_weight: "40000 wu",
             weighted_utxos: &["e(1 sats)/68 vB"],
-            expected_utxos: &[],
-            expected_error: Some(Overflow(Addition)),
-            expected_iterations: 0,
+            expected_utxos: &["e(1 sats)/68 vB"],
+            expected_error: None,
+            expected_iterations: 1,
         }
         .assert();
     }

--- a/src/branch_and_bound.rs
+++ b/src/branch_and_bound.rs
@@ -8,8 +8,6 @@ use bitcoin_units::{Amount, FeeRate, Weight};
 
 use crate::build_lookahead;
 use crate::weighted_utxo::WeightedUtxo;
-use crate::OverflowError::Addition;
-use crate::SelectionError::Overflow;
 use crate::{Return, ReturnSub, SelectionError, Spendable, ITERATION_LIMIT};
 
 /// Deterministic depth first branch and bound search for a changeless solution.
@@ -332,6 +330,8 @@ mod tests {
     use crate::tests::{
         assert_ref_eq, effective_sum, parse_fee_rate, utxos_from_str, weight_sum, Pool, Utxo,
     };
+    use crate::OverflowError::Addition;
+    use crate::SelectionError::Overflow;
     use crate::SelectionError::{
         InsufficentFunds, IterationLimitReached, MaxWeightExceeded, ProgramError, SolutionNotFound,
     };
@@ -928,7 +928,7 @@ mod tests {
                     let utxos: Vec<_> = utxos.iter().map(|&u| u.clone()).collect();
                     let eff_value_sum = effective_sum(&utxos, fee_rate).unwrap();
                     assert!(eff_value_sum >= target);
-                    assert!(eff_value_sum <= upper_bound.unwrap());
+                    assert!(eff_value_sum <= upper_bound.unwrap_or(Amount::MAX));
                 }
                 Err(InsufficentFunds) => {
                     let available_value = effective_sum(&utxos, fee_rate).unwrap();


### PR DESCRIPTION
The search can still succeed even if the calculating the upper bound overflows by simply saturating the upper bound to Amount::MAX.  Furthermore, logic is simplified by not needing to handle an overflow error.